### PR TITLE
Use Psi elements instead of AST

### DIFF
--- a/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/generating/SqlDocumentAnnotator.kt
+++ b/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/generating/SqlDocumentAnnotator.kt
@@ -15,13 +15,13 @@
  */
 package com.squareup.sqldelight.generating
 
-import com.intellij.lang.ASTNode
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.squareup.sqldelight.SqliteCompiler
 import com.squareup.sqldelight.SqliteCompiler.Status
@@ -29,7 +29,7 @@ import com.squareup.sqldelight.lang.SqliteFile
 
 internal class SqlDocumentAnnotator : ExternalAnnotator<Pair<SqliteFile, TableGenerator>, SqlDocumentAnnotator.Generation>() {
   private val localFileSystem = LocalFileSystem.getInstance()
-  private val sqliteCompiler = SqliteCompiler<ASTNode>()
+  private val sqliteCompiler = SqliteCompiler<PsiElement>()
 
   override fun collectInformation(file: PsiFile) = Pair(file as SqliteFile, TableGenerator.create(file))
 
@@ -60,5 +60,5 @@ internal class SqlDocumentAnnotator : ExternalAnnotator<Pair<SqliteFile, TableGe
     }
   }
 
-  class Generation internal constructor(val status: Status<ASTNode>, val generatedFile: VirtualFile?)
+  class Generation internal constructor(val status: Status<PsiElement>, val generatedFile: VirtualFile?)
 }

--- a/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/util/PsiUtil.kt
+++ b/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/util/PsiUtil.kt
@@ -19,6 +19,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
+import org.antlr.intellij.adaptor.lexer.RuleElementType
+import org.antlr.intellij.adaptor.lexer.TokenElementType
 
 internal inline fun <reified R : PsiElement> PsiElement.parentOfType(): R? =
     PsiTreeUtil.getParentOfType(this, R::class.java)
@@ -42,3 +44,11 @@ internal fun PsiFile.processElements(processor: (element: PsiElement) -> Boolean
 
 internal val PsiElement.elementType: IElementType
     get() = node.elementType
+
+internal fun PsiElement.childrenForRule(rule: Int) = children.filter {
+      when (it.elementType) {
+        is TokenElementType -> (it.elementType as TokenElementType).type == rule
+        is RuleElementType -> (it.elementType as RuleElementType).ruleIndex == rule
+        else -> false
+      }
+    }

--- a/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/util/SqlitePsiUtils.kt
+++ b/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/util/SqlitePsiUtils.kt
@@ -15,27 +15,15 @@
  */
 package com.squareup.sqldelight.util
 
-import com.intellij.lang.ASTNode
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.impl.PsiFileFactoryImpl
 import com.intellij.psi.tree.IElementType
-import com.squareup.sqldelight.SqliteParser
 import com.squareup.sqldelight.lang.SqliteLanguage
-import org.antlr.intellij.adaptor.lexer.ElementTypeFactory
 
 object SqlitePsiUtils {
   fun createLeafFromText(project: Project, context: PsiElement?, text: String, type: IElementType) =
       (PsiFileFactory.getInstance(project) as PsiFileFactoryImpl)
           .createElementFromText(text, SqliteLanguage.INSTANCE, type, context)!!.getDeepestFirst()
 }
-
-internal val RULES = SqliteParser.ruleNames.asList()
-private val TOKENS = SqliteParser.tokenNames.asList()
-
-internal fun ASTNode.childrenWithRules(vararg rules: Int) = getChildren(
-    ElementTypeFactory.createRuleSet(SqliteLanguage.INSTANCE, RULES, *rules))
-
-internal fun ASTNode.childrenWithTokens(vararg tokens: Int) = getChildren(
-    ElementTypeFactory.createTokenSet(SqliteLanguage.INSTANCE, TOKENS, *tokens))


### PR DESCRIPTION
We can provide our own implementations of PsiElements, which will be necessary for the NameAllocator changes and probably others. Also the Psi layer of abstraction is what the rest of the codebase uses.