### PR TITLE
Create the model files on creation and during the synchronization step

### DIFF
--- a/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/generating/SqlDocumentAnnotator.kt
+++ b/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/generating/SqlDocumentAnnotator.kt
@@ -17,48 +17,22 @@ package com.squareup.sqldelight.generating
 
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
-import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.squareup.sqldelight.SqliteCompiler
 import com.squareup.sqldelight.SqliteCompiler.Status
 import com.squareup.sqldelight.lang.SqliteFile
 
-internal class SqlDocumentAnnotator : ExternalAnnotator<Pair<SqliteFile, TableGenerator>, SqlDocumentAnnotator.Generation>() {
-  private val localFileSystem = LocalFileSystem.getInstance()
-  private val sqliteCompiler = SqliteCompiler<PsiElement>()
-
-  override fun collectInformation(file: PsiFile) = Pair(file as SqliteFile, TableGenerator.create(file))
-
-  override fun doAnnotate(pair: Pair<SqliteFile, TableGenerator>): Generation? {
-    val tableGenerator = pair.second
-    val status = sqliteCompiler.write(tableGenerator)
-    val file = localFileSystem.findFileByIoFile(tableGenerator.outputDirectory)
-    file?.refresh(false, true)
-    val generatedFile = file?.findFileByRelativePath(
-        tableGenerator.packageDirectory + "/" + tableGenerator.generatedFileName + ".java")
-    if (generatedFile != pair.first.generatedFile?.virtualFile) {
-      WriteCommandAction.runWriteCommandAction(pair.first.project, { pair.first.generatedFile?.delete() })
-    }
-    return Generation(status, generatedFile)
-  }
-
-  override fun apply(file: PsiFile, generation: Generation, holder: AnnotationHolder) {
-    when (generation.status.result) {
-      SqliteCompiler.Status.Result.FAILURE -> holder.createErrorAnnotation(
-          generation.status.originatingElement,
-          generation.status.errorMessage)
-      SqliteCompiler.Status.Result.SUCCESS -> {
-        if (generation.generatedFile == null) return
-        val document = FileDocumentManager.getInstance().getDocument(generation.generatedFile)
-        document?.createGuardedBlock(0, document.textLength)
-        (file as SqliteFile).generatedFile = file.getManager().findFile(generation.generatedFile)
-      }
+internal class SqlDocumentAnnotator : ExternalAnnotator<Status<PsiElement>, Status<PsiElement>>() {
+  override fun collectInformation(file: PsiFile) = (file as SqliteFile).status
+  override fun doAnnotate(status: Status<PsiElement>) = status
+  override fun apply(file: PsiFile, status: Status<PsiElement>, holder: AnnotationHolder) {
+    if (status.result == Status.Result.FAILURE) {
+      holder.createErrorAnnotation(status.originatingElement, status.errorMessage)
+    } else {
+      val generatedFile = (file as SqliteFile).generatedFile ?: return
+      val document = FileDocumentManager.getInstance().getDocument(generatedFile.virtualFile)
+      document?.createGuardedBlock(0, document.textLength)
     }
   }
-
-  class Generation internal constructor(val status: Status<PsiElement>, val generatedFile: VirtualFile?)
 }

--- a/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/lang/SqlDelightFileViewProviderFactory.kt
+++ b/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/lang/SqlDelightFileViewProviderFactory.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqldelight.lang
+
+import com.intellij.lang.Language
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.*
+import com.squareup.sqldelight.SqliteCompiler
+import com.squareup.sqldelight.generating.TableGenerator
+
+class SqlDelightFileViewProviderFactory : FileViewProviderFactory {
+  override fun createFileViewProvider(virtualFile: VirtualFile, language: Language,
+      psiManager: PsiManager, eventSystemEnabled: Boolean): FileViewProvider {
+    return SqlDelightFileViewProvider(virtualFile, language, psiManager, eventSystemEnabled)
+  }
+}
+
+internal class SqlDelightFileViewProvider(virtualFile: VirtualFile, language: Language,
+    val psiManager: PsiManager, eventSystemEnabled: Boolean) :
+    SingleRootFileViewProvider(psiManager, virtualFile, eventSystemEnabled,
+        language, SqliteFileType.INSTANCE) {
+
+  val documentManager = PsiDocumentManager.getInstance(psiManager.project)
+
+  init {
+    ApplicationManager.getApplication().executeOnPooledThread {
+      WriteCommandAction.runWriteCommandAction(psiManager.project, { generateJavaInterface() })
+    }
+  }
+
+  override fun contentsSynchronized() {
+    super.contentsSynchronized()
+    documentManager.performWhenAllCommitted { generateJavaInterface() }
+  }
+
+  private fun generateJavaInterface() {
+    val file = getPsiInner(SqliteLanguage.INSTANCE) as SqliteFile
+    val tableGenerator: TableGenerator
+    try {
+      tableGenerator = TableGenerator.create(file)
+    } catch (ignored: Exception) {
+      // Ignoring exceptions here since the syntax highlighter handles language-level errors.
+      return
+    }
+    file.status = sqliteCompiler.write(tableGenerator)
+    val outputDirectory = localFileSystem.findFileByIoFile(tableGenerator.outputDirectory)
+    outputDirectory?.refresh(false, true)
+    val generatedFile = outputDirectory?.findFileByRelativePath(
+        tableGenerator.packageDirectory + "/" + tableGenerator.generatedFileName + ".java")
+    if (generatedFile != file.generatedFile?.virtualFile) {
+      file.generatedFile?.delete()
+    }
+    file.generatedFile = psiManager.findFile(generatedFile ?: return)
+  }
+
+  companion object {
+    private val localFileSystem = LocalFileSystem.getInstance()
+    private val sqliteCompiler = SqliteCompiler<PsiElement>()
+  }
+}

--- a/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/lang/SqliteFile.kt
+++ b/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/lang/SqliteFile.kt
@@ -17,11 +17,14 @@ package com.squareup.sqldelight.lang
 
 import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.squareup.sqldelight.SqliteCompiler.Status
 
 class SqliteFile internal constructor(viewProvider: FileViewProvider)
 : PsiFileBase(viewProvider, SqliteLanguage.INSTANCE) {
   var generatedFile: PsiFile? = null
+  var status: Status<PsiElement>? = null
 
   override fun getFileType() = SqliteFileType.INSTANCE
   override fun toString() = "SQLite file"

--- a/sqldelight-studio-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-studio-plugin/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,8 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <fileTypeFactory implementation="com.squareup.sqldelight.lang.SqliteFileTypeFactory"/>
+    <lang.fileViewProviderFactory language="Sqlite" implementationClass="com.squareup.sqldelight.lang.SqlDelightFileViewProviderFactory" />
+
     <externalAnnotator language="Sqlite"
         implementationClass="com.squareup.sqldelight.generating.SqlDocumentAnnotator"/>
     <gotoDeclarationHandler


### PR DESCRIPTION
Closes #44

Also fixes an issue where model files aren't generated until you open the `.sq` file