### PR TITLE
Update to IDEA 15.0.4.

### DIFF
--- a/sqldelight-studio-plugin/build.gradle
+++ b/sqldelight-studio-plugin/build.gradle
@@ -10,7 +10,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 
 intellij {
   updateSinceUntilBuild false
-  version 'IC-15.0.1'
+  version 'IC-15.0.4'
   plugins = ['properties', 'Groovy', 'gradle', 'junit', 'android']
   pluginName = 'SQLDelight'
 }


### PR DESCRIPTION
This has the Kotlin 1.0 plugin which should resolve the mismatch warnings during development.