### PR TITLE
Dont duplicate the error annotations if many queries in the file reference a broken table

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/Status.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/Status.kt
@@ -21,14 +21,14 @@ import java.io.File
 sealed class Status(val originatingElement: ParserRuleContext) {
   class Success(element: ParserRuleContext, val generatedFile: File) : Status(element)
   class Failure(element: ParserRuleContext, val errorMessage: String) : Status(element)
-  sealed class ValidationStatus(element: ParserRuleContext, val dependencies: Set<Any>) : Status(element) {
+  sealed class ValidationStatus(element: ParserRuleContext, val dependencies: Collection<Any>) : Status(element) {
     class Validated(
         element: ParserRuleContext,
-        dependencies: Set<Any>
+        dependencies: Collection<Any>
     ) : ValidationStatus(element, dependencies)
     class Invalid(
-        val exceptions: List<SqlitePluginException>,
-        dependencies: Set<Any>
-    ) : ValidationStatus(exceptions[0].originatingElement, dependencies)
+        val exceptions: Collection<SqlitePluginException>,
+        dependencies: Collection<Any>
+    ) : ValidationStatus(exceptions.first().originatingElement, dependencies)
   }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/types/ForeignKey.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/types/ForeignKey.kt
@@ -17,7 +17,6 @@ package com.squareup.sqldelight.types
 
 import com.squareup.sqldelight.SqliteParser
 import com.squareup.sqldelight.SqlitePluginException
-import com.squareup.sqldelight.model.javaType
 import java.util.ArrayList
 
 internal class ForeignKey private constructor(
@@ -53,8 +52,7 @@ internal class ForeignKey private constructor(
 
       table.column_def().forEach { column ->
         if (column.column_constraint().filter { it.K_UNIQUE() != null }.isNotEmpty()) {
-          result.add(listOf(
-              Value(table.table_name().text, column.column_name().text, column.javaType, column)))
+          result.add(listOf(Value(table.table_name().text, column)))
         }
       }
 
@@ -90,8 +88,7 @@ internal class ForeignKey private constructor(
         if (table.table_constraint().any { it.K_PRIMARY_KEY() != null }) {
           throw SqlitePluginException(table, "Can only have one primary key on a table")
         }
-        return listOf(Value(table.table_name().text, primaryKeys[0].column_name().text,
-            primaryKeys[0].javaType, primaryKeys[0]))
+        return listOf(Value(table.table_name().text, primaryKeys[0]))
       }
 
       val tablePrimaryKeys = table.table_constraint().filter { it.K_PRIMARY_KEY() != null }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/types/Resolver.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/types/Resolver.kt
@@ -15,10 +15,8 @@
  */
 package com.squareup.sqldelight.types
 
-import com.squareup.javapoet.TypeName
 import com.squareup.sqldelight.SqliteParser
 import com.squareup.sqldelight.SqlitePluginException
-import com.squareup.sqldelight.model.javaType
 import com.squareup.sqldelight.validation.JoinValidator
 import com.squareup.sqldelight.validation.ResultColumnValidator
 import com.squareup.sqldelight.validation.SelectOrValuesValidator
@@ -201,7 +199,7 @@ internal class Resolver(
     }
 
     // TODO get the actual type of the expression. Thats gonna be fun. :(
-    return Value(null, null, TypeName.VOID, expression)
+    return Value(null, null, Value.SqliteType.INTEGER, expression)
   }
 
   /**
@@ -255,9 +253,7 @@ internal class Resolver(
   }
 
   fun resolve(createTable: SqliteParser.Create_table_stmtContext) =
-      createTable.column_def().map {
-        Value(createTable.table_name().text, it.column_name().text, it.javaType, it)
-      }
+      createTable.column_def().map { Value(createTable.table_name().text, it) }
 
   fun resolve(parserRuleContext: ParserRuleContext): List<Value> {
     when (parserRuleContext) {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/types/Value.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/types/Value.kt
@@ -15,15 +15,26 @@
  */
 package com.squareup.sqldelight.types
 
-import com.squareup.javapoet.TypeName
+import com.squareup.sqldelight.SqliteParser
 import org.antlr.v4.runtime.ParserRuleContext
 
 internal data class Value(
     internal val tableName: String?,
     internal val columnName: String?,
-    internal val type: TypeName,
+    internal val type: SqliteType,
     internal val element: ParserRuleContext
-)
+) {
+  constructor(tableName: String?, column: SqliteParser.Column_defContext) : this(
+      tableName,
+      column.column_name().text,
+      SqliteType.valueOf(column.type_name().sqlite_type_name().text),
+      column
+  )
+
+  enum class SqliteType {
+    INTEGER, REAL, TEXT, BLOB
+  }
+}
 
 internal fun List<Value>.columns(columnName: String, tableName: String?) = filter {
   it.columnName != null && it.columnName == columnName && (tableName == null || it.tableName == tableName)


### PR DESCRIPTION
Also use the sqlite type during resolution so erroneous java types dont throw