### PR TITLE
Revert "Removes public modifier from generated interfaces."

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import java.lang.String;
 
-interface HockeyPlayerModel {
+public interface HockeyPlayerModel {
   String TABLE_NAME = "hockey_player";
 
   String _ID = "_id";
@@ -109,12 +109,6 @@ interface HockeyPlayerModel {
     }
   }
 }
-```
-
-By default, the generated interface is package private. To access it publicly, you can simply subclass it with an empty implementation.
-
-```java
-public interface HockeyPlayer extends HockeyPlayerModel { }
 ```
 
 AutoValue

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/SqliteCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/SqliteCompiler.kt
@@ -49,6 +49,7 @@ class SqliteCompiler {
       val packageName = relativePath.split(File.separatorChar).dropLast(1).joinToString(".")
       val className = interfaceName(fileName)
       val typeSpec = TypeSpec.interfaceBuilder(className)
+          .addModifiers(PUBLIC)
 
       if (parseContext.sql_stmt_list().create_table_stmt() != null) {
         val table = parseContext.sql_stmt_list().create_table_stmt()

--- a/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/expected/com/test/UserModel.java
@@ -8,7 +8,7 @@ import com.squareup.sqldelight.RowMapper;
 import java.lang.Override;
 import java.lang.String;
 
-interface UserModel {
+public interface UserModel {
   String TABLE_NAME = "user";
 
   String BALANCE = "balance";

--- a/sqldelight-gradle-plugin/src/test/fixtures/expression-like/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/expression-like/expected/com/sample/TestModel.java
@@ -7,7 +7,7 @@ import com.squareup.sqldelight.RowMapper;
 import java.lang.Override;
 import java.lang.String;
 
-interface TestModel {
+public interface TestModel {
   String TABLE_NAME = "employee";
 
   String ID = "id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullable-boolean/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullable-boolean/expected/com/test/UserModel.java
@@ -9,7 +9,7 @@ import java.lang.Boolean;
 import java.lang.Override;
 import java.lang.String;
 
-interface UserModel {
+public interface UserModel {
   String TABLE_NAME = "users";
 
   String TALL = "tall";

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullable-enum/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullable-enum/expected/com/test/UserModel.java
@@ -9,7 +9,7 @@ import com.squareup.sqldelight.RowMapper;
 import java.lang.Override;
 import java.lang.String;
 
-interface UserModel {
+public interface UserModel {
   String TABLE_NAME = "users";
 
   String GENDER = "gender";

--- a/sqldelight-gradle-plugin/src/test/fixtures/sql-types-to-java-types/expected/com/test/TypeModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/sql-types-to-java-types/expected/com/test/TypeModel.java
@@ -14,7 +14,7 @@ import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
-interface TypeModel {
+public interface TypeModel {
   String TABLE_NAME = "types";
 
   String I = "i";

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
@@ -11,7 +11,7 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.Calendar;
 
-interface HockeyPlayerModel {
+public interface HockeyPlayerModel {
   String TABLE_NAME = "hockey_player";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/TeamModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/TeamModel.java
@@ -11,7 +11,7 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.Calendar;
 
-interface TeamModel {
+public interface TeamModel {
   String TABLE_NAME = "team";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/expected/com/test/UserModel.java
@@ -9,7 +9,7 @@ import com.squareup.sqldelight.RowMapper;
 import java.lang.Override;
 import java.lang.String;
 
-interface UserModel {
+public interface UserModel {
   String TABLE_NAME = "users";
 
   String ID = "id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine/expected/com/test/UserModel.java
@@ -9,7 +9,7 @@ import com.squareup.sqldelight.RowMapper;
 import java.lang.Override;
 import java.lang.String;
 
-interface UserModel {
+public interface UserModel {
   String TABLE_NAME = "users";
 
   String ID = "id";


### PR DESCRIPTION
This reverts commit 03854d003c21e6237872c7e88f4ce99155215a41.

cc @rharter.

There's a JDK compiler bug with method references that this change can trip in ways that only fail when you exercise certain code paths at runtime. This is far too risky for us to ship at this time. If the bug gets fixed for later JDK 8 builds and/or JDK 9 we can revisit this change (hopefully before a 1.0).

The bug is not public yet. I will try to remember to link it here when it's made public by Oracle.