### PR TITLE
Use source directory instead of module file

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/model/File.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/model/File.kt
@@ -23,7 +23,18 @@ fun String.relativePath(originatingElement: ParserRuleContext): String {
   val parts = split(File.separatorChar)
   for (i in 2..parts.size) {
     if (parts[i - 2] == "src" && parts[i] == "sqldelight") {
-      return parts.subList(i + 1, parts.size).joinToString(File.separatorChar.toString())
+      return parts.subList(i + 1, parts.size).joinToString(File.separator)
+    }
+  }
+  throw SqlitePluginException(originatingElement,
+      "Files must be organized like src/main/sqldelight/...")
+}
+
+fun String.moduleDirectory(originatingElement: ParserRuleContext): String {
+  val parts = split(File.separatorChar)
+  for (i in 2..parts.size) {
+    if (parts[i - 2] == "src" && parts[i] == "sqldelight") {
+      return parts.subList(0, i - 2).joinToString(File.separator)
     }
   }
   throw SqlitePluginException(originatingElement,

--- a/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
+++ b/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
@@ -17,7 +17,6 @@ package com.squareup.sqldelight.intellij.lang
 
 import com.intellij.lang.Language
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.FileViewProvider
@@ -29,6 +28,7 @@ import com.intellij.util.containers.MultiMap
 import com.squareup.sqldelight.SqliteCompiler
 import com.squareup.sqldelight.Status
 import com.squareup.sqldelight.Status.ValidationStatus.Invalid
+import com.squareup.sqldelight.model.moduleDirectory
 import com.squareup.sqldelight.model.relativePath
 import com.squareup.sqldelight.types.SymbolTable
 import com.squareup.sqldelight.validation.SqlDelightValidator
@@ -81,7 +81,7 @@ internal class SqlDelightFileViewProvider(virtualFile: VirtualFile, language: La
           parsed,
           virtualFile.nameWithoutExtension,
           virtualFile.getPlatformSpecificPath().relativePath(parsed),
-          (ModuleUtil.findModuleForPsiElement(file)!!.moduleFile?.parent?.getPlatformSpecificPath() ?: "") + File.separatorChar
+          virtualFile.getPlatformSpecificPath().moduleDirectory(parsed) + File.separatorChar
       )
 
       if (file.status is Status.Success) {


### PR DESCRIPTION
Noticed this while testing against IJ 2016 since it stores the module file under the `.idea` directory. This change will always place the generated files sibling to the `src` directory, which is the behavior we want.

net 11 lines added, happy jake?