### PR TITLE
If an antlr exception causes a rule to break dont add that rule to the symbol table

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/types/SymbolTable.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/types/SymbolTable.kt
@@ -42,13 +42,13 @@ class SymbolTable constructor(
   ) : this(
       listOf(parsed.sql_stmt_list().create_table_stmt())
         .filterNotNull()
-        .filter { !errors.hasTokenIn(it) }
+        .filter { it.exception == null && !errors.hasTokenIn(it) }
         .map { it.table_name().text to it }
         .toMap(),
       parsed.sql_stmt_list().sql_stmt()
           .map { it.create_view_stmt() }
           .filterNotNull()
-          .filter { !errors.hasTokenIn(it) }
+          .filter { it.exception == null && !errors.hasTokenIn(it) }
           .groupBy { it.view_name().text }
           .map {
             val (viewName, views) = it
@@ -61,7 +61,7 @@ class SymbolTable constructor(
       indexes = parsed.sql_stmt_list().sql_stmt()
           .map { it.create_index_stmt() }
           .filterNotNull()
-          .filter { !errors.hasTokenIn(it) }
+          .filter { it.exception == null && !errors.hasTokenIn(it) }
           .groupBy { it.index_name().text }
           .map {
             val (indexName, indexes) = it
@@ -74,7 +74,7 @@ class SymbolTable constructor(
       triggers = parsed.sql_stmt_list().sql_stmt()
           .map { it.create_trigger_stmt() }
           .filterNotNull()
-          .filter { !errors.hasTokenIn(it) }
+          .filter { it.exception == null && !errors.hasTokenIn(it) }
           .groupBy { it.trigger_name().text }
           .map {
             val (triggerName, triggers) = it

--- a/sqldelight-studio-plugin/testData/main/Test4.sq
+++ b/sqldelight-studio-plugin/testData/main/Test4.sq
@@ -1,0 +1,2 @@
+-- This file throws an antlr exception and so shouldn't be added to the symbol table.
+CREATE TABLE           


### PR DESCRIPTION
Closes #304 

antlr treats "errors" and "exceptions" differently, not sure why

`sqldelight-studio-plugin/testData/main/Test3.sq` raises an antlr Error
`sqldelight-studio-plugin/testData/main/Test4.sq` (added in PR) throws an antlr exception
