### PR TITLE
Antlr exceptions shouldnt cause problems if the text range is invalid

### DIFF
--- a/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDocumentAnnotator.kt
+++ b/sqldelight-studio-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDocumentAnnotator.kt
@@ -34,8 +34,14 @@ internal class SqlDocumentAnnotator : ExternalAnnotator<Status?, Status?>() {
       }
       is Status.ValidationStatus.Invalid -> {
         for (error in status.errors) {
-          holder.createErrorAnnotation(TextRange(error.originatingElement.start.startIndex,
-              error.originatingElement.stop.stopIndex + 1), error.errorMessage)
+          if (error.originatingElement.start.startIndex > error.originatingElement.stop.stopIndex) {
+            // This can happen if antlr threw an exception parsing. It should happen rarely or not
+            // at all but if it does just error the whole file.
+            holder.createErrorAnnotation(file, error.errorMessage)
+          } else {
+            holder.createErrorAnnotation(TextRange(error.originatingElement.start.startIndex,
+                error.originatingElement.stop.stopIndex + 1), error.errorMessage)
+          }
         }
       }
       is Status.Success -> {


### PR DESCRIPTION
```
Invalid range specified: (3323,3322); 
com.intellij.openapi.diagnostic.Logger$EmptyThrowable
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:129)
	at com.intellij.openapi.util.TextRange.assertProperRange(TextRange.java:220)
	at com.intellij.openapi.util.TextRange.assertProperRange(TextRange.java:215)
	at com.intellij.openapi.util.TextRange.assertProperRange(TextRange.java:211)
	at com.intellij.openapi.util.TextRange.<init>(TextRange.java:43)
	at com.intellij.openapi.util.TextRange.<init>(TextRange.java:32)
	at com.squareup.sqldelight.intellij.lang.SqlDocumentAnnotator.apply(SqlDocumentAnnotator.kt:37)
	at com.squareup.sqldelight.intellij.lang.SqlDocumentAnnotator.apply(SqlDocumentAnnotator.kt:25)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.applyRelevant(ExternalToolPass.java:195)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass.access$700(ExternalToolPass.java:44)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass$1$1.run(ExternalToolPass.java:168)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1181)
	at com.intellij.codeInsight.daemon.impl.ExternalToolPass$1.run(ExternalToolPass.java:162)
	at com.intellij.util.ui.update.MergingUpdateQueue.execute(MergingUpdateQueue.java:333)
	at com.intellij.util.ui.update.MergingUpdateQueue.execute(MergingUpdateQueue.java:323)
	at com.intellij.util.ui.update.MergingUpdateQueue$3.run(MergingUpdateQueue.java:267)
	at com.intellij.util.ui.update.MergingUpdateQueue.flush(MergingUpdateQueue.java:282)
	at com.intellij.util.ui.update.MergingUpdateQueue.run(MergingUpdateQueue.java:234)
	at com.intellij.util.concurrency.QueueProcessor.runSafely(QueueProcessor.java:238)
	at com.intellij.util.Alarm$Request$1.run(Alarm.java:378)
	at com.intellij.util.Alarm$Request.run(Alarm.java:389)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at com.intellij.util.concurrency.SchedulingWrapper$MyScheduledFutureTask.run(SchedulingWrapper.java:227)
	at com.intellij.util.concurrency.BoundedTaskExecutor$2.run(BoundedTaskExecutor.java:187)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```