### PR TITLE
Always package scope the mapper constructor.

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/MapperSpec.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/MapperSpec.kt
@@ -83,7 +83,6 @@ internal class MapperSpec private constructor(private val nameAllocators: Mutabl
         .addField(creatorType, Table.CREATOR_FIELD, Modifier.PRIVATE, Modifier.FINAL)
 
     val constructor = MethodSpec.constructorBuilder()
-        .addModifiers(if (isView) Modifier.PUBLIC else Modifier.PRIVATE)
         .addParameter(creatorType, Table.CREATOR_FIELD)
         .addStatement("this.${Table.CREATOR_FIELD} = ${Table.CREATOR_FIELD}")
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/column-casing/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/column-casing/expected/com/sample/TestModel.java
@@ -56,7 +56,7 @@ public interface TestModel {
   final class Some_selectMapper<T extends Some_selectModel> implements RowMapper<T> {
     private final Some_selectCreator<T> creator;
 
-    private Some_selectMapper(Some_selectCreator<T> creator) {
+    Some_selectMapper(Some_selectCreator<T> creator) {
       this.creator = creator;
     }
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
@@ -72,7 +72,7 @@ public interface Test1Model {
 
     private final View1Creator<V1> view1Creator;
 
-    private Other_selectMapper(Other_selectCreator<T3, V1, T> creator, Factory<T3> test1ModelFactory, View1Creator<V1> view1Creator) {
+    Other_selectMapper(Other_selectCreator<T3, V1, T> creator, Factory<T3> test1ModelFactory, View1Creator<V1> view1Creator) {
       this.creator = creator;
       this.test1ModelFactory = test1ModelFactory;
       this.view1Creator = view1Creator;
@@ -110,7 +110,7 @@ public interface Test1Model {
 
     private final View1Creator<V1> view1Creator;
 
-    private Same_viewMapper(Same_viewCreator<V1, T> creator, View1Creator<V1> view1Creator) {
+    Same_viewMapper(Same_viewCreator<V1, T> creator, View1Creator<V1> view1Creator) {
       this.creator = creator;
       this.view1Creator = view1Creator;
     }
@@ -144,7 +144,7 @@ public interface Test1Model {
   final class View1Mapper<T extends View1Model> implements RowMapper<T> {
     private final View1Creator<T> creator;
 
-    public View1Mapper(View1Creator<T> creator) {
+    View1Mapper(View1Creator<T> creator) {
       this.creator = creator;
     }
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
@@ -116,7 +116,7 @@ public interface Test2Model {
 
     private final Test1Model.View1Creator<V4> view1Creator;
 
-    private Other_selectMapper(Other_selectCreator<T1, V4, T> creator, Factory<T1> test2ModelFactory, Test1Model.View1Creator<V4> view1Creator) {
+    Other_selectMapper(Other_selectCreator<T1, V4, T> creator, Factory<T1> test2ModelFactory, Test1Model.View1Creator<V4> view1Creator) {
       this.creator = creator;
       this.test2ModelFactory = test2ModelFactory;
       this.view1Creator = view1Creator;
@@ -160,7 +160,7 @@ public interface Test2Model {
 
     private final Multiple_tablesCreator<V4T4, V1T1, V4> multiple_tablesCreator;
 
-    private Multiple_view_selectMapper(Multiple_view_selectCreator<V1T1, V1, V4T4, V4, T> creator, Factory<V1T1> test2ModelFactory, Test2_copyCreator<V1T1, V1> test2_copyCreator, Test1Model.Factory<V4T4> test1ModelFactory, Multiple_tablesCreator<V4T4, V1T1, V4> multiple_tablesCreator) {
+    Multiple_view_selectMapper(Multiple_view_selectCreator<V1T1, V1, V4T4, V4, T> creator, Factory<V1T1> test2ModelFactory, Test2_copyCreator<V1T1, V1> test2_copyCreator, Test1Model.Factory<V4T4> test1ModelFactory, Multiple_tablesCreator<V4T4, V1T1, V4> multiple_tablesCreator) {
       this.creator = creator;
       this.test2ModelFactory = test2ModelFactory;
       this.test2_copyCreator = test2_copyCreator;
@@ -212,7 +212,7 @@ public interface Test2Model {
 
     private final Test1Model.View1Creator<V1> view1Creator;
 
-    private Views_and_columns_selectMapper(Views_and_columns_selectCreator<V1, T> creator, Test1Model.View1Creator<V1> view1Creator) {
+    Views_and_columns_selectMapper(Views_and_columns_selectCreator<V1, T> creator, Test1Model.View1Creator<V1> view1Creator) {
       this.creator = creator;
       this.view1Creator = view1Creator;
     }
@@ -257,7 +257,7 @@ public interface Test2Model {
 
     private final Test2_copyCreator<V6T6, V6> test2_copyCreator;
 
-    private Select_from_sub_viewMapper(Select_from_sub_viewCreator<V1V1, V1, V6T6, V6, T> creator, Sub_viewCreator<V1V1, V1> sub_viewCreator, Test1Model.View1Creator<V1V1> view1Creator, Factory<V6T6> test2ModelFactory, Test2_copyCreator<V6T6, V6> test2_copyCreator) {
+    Select_from_sub_viewMapper(Select_from_sub_viewCreator<V1V1, V1, V6T6, V6, T> creator, Sub_viewCreator<V1V1, V1> sub_viewCreator, Test1Model.View1Creator<V1V1> view1Creator, Factory<V6T6> test2ModelFactory, Test2_copyCreator<V6T6, V6> test2_copyCreator) {
       this.creator = creator;
       this.sub_viewCreator = sub_viewCreator;
       this.view1Creator = view1Creator;
@@ -353,7 +353,7 @@ public interface Test2Model {
   final class View1Mapper<T extends Test1Model.View1Model> implements RowMapper<T> {
     private final Test1Model.View1Creator<T> creator;
 
-    public View1Mapper(Test1Model.View1Creator<T> creator) {
+    View1Mapper(Test1Model.View1Creator<T> creator) {
       this.creator = creator;
     }
 
@@ -372,7 +372,7 @@ public interface Test2Model {
 
     private final Factory<T1> test2ModelFactory;
 
-    public Test2_copyMapper(Test2_copyCreator<T1, T> creator, Factory<T1> test2ModelFactory) {
+    Test2_copyMapper(Test2_copyCreator<T1, T> creator, Factory<T1> test2ModelFactory) {
       this.creator = creator;
       this.test2ModelFactory = test2ModelFactory;
     }
@@ -395,7 +395,7 @@ public interface Test2Model {
 
     private final Test1Model.Factory<T1> test1ModelFactory;
 
-    public Projection_viewMapper(Projection_viewCreator<T> creator, Test1Model.Factory<T1> test1ModelFactory) {
+    Projection_viewMapper(Projection_viewCreator<T> creator, Test1Model.Factory<T1> test1ModelFactory) {
       this.creator = creator;
       this.test1ModelFactory = test1ModelFactory;
     }
@@ -415,7 +415,7 @@ public interface Test2Model {
 
     private final Factory<T1> test2ModelFactory;
 
-    public Test2_projectionMapper(Test2_projectionCreator<T> creator, Factory<T1> test2ModelFactory) {
+    Test2_projectionMapper(Test2_projectionCreator<T> creator, Factory<T1> test2ModelFactory) {
       this.creator = creator;
       this.test2ModelFactory = test2ModelFactory;
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/sample/Test1Model.java
@@ -53,7 +53,7 @@ public interface Test1Model {
 
     private final Test2Model.Factory<T3> test2ModelFactory;
 
-    private Join_tablesMapper(Join_tablesCreator<T1, T3, T> creator, Factory<T1> test1ModelFactory, Test2Model.Factory<T3> test2ModelFactory) {
+    Join_tablesMapper(Join_tablesCreator<T1, T3, T> creator, Factory<T1> test1ModelFactory, Test2Model.Factory<T3> test2ModelFactory) {
       this.creator = creator;
       this.test1ModelFactory = test1ModelFactory;
       this.test2ModelFactory = test2ModelFactory;

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/test/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/test/Test2Model.java
@@ -45,7 +45,7 @@ public interface Test2Model {
 
     private final Test1Model.Factory<T2> test1ModelFactory;
 
-    private Join_tablesMapper(Join_tablesCreator<T1, T2, T> creator, Factory<T1> test2ModelFactory, Test1Model.Factory<T2> test1ModelFactory) {
+    Join_tablesMapper(Join_tablesCreator<T1, T2, T> creator, Factory<T1> test2ModelFactory, Test1Model.Factory<T2> test1ModelFactory) {
       this.creator = creator;
       this.test2ModelFactory = test2ModelFactory;
       this.test1ModelFactory = test1ModelFactory;

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/thing/Test3Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/thing/Test3Model.java
@@ -62,7 +62,7 @@ public interface Test3Model {
 
     private final Test2Model.Factory<T3> test2ModelFactory;
 
-    private Join_tablesMapper(Join_tablesCreator<T1, T3, T> creator, Test1Model.Factory<T1> test1ModelFactory, Test2Model.Factory<T3> test2ModelFactory) {
+    Join_tablesMapper(Join_tablesCreator<T1, T3, T> creator, Test1Model.Factory<T1> test1ModelFactory, Test2Model.Factory<T3> test2ModelFactory) {
       this.creator = creator;
       this.test1ModelFactory = test1ModelFactory;
       this.test2ModelFactory = test2ModelFactory;
@@ -102,7 +102,7 @@ public interface Test3Model {
 
     private final Test2Model.Factory<T4> test2ModelFactory;
 
-    private Tables_and_valueMapper(Tables_and_valueCreator<T1, T4, T> creator, Test1Model.Factory<T1> test1ModelFactory, Test2Model.Factory<T4> test2ModelFactory) {
+    Tables_and_valueMapper(Tables_and_valueCreator<T1, T4, T> creator, Test1Model.Factory<T1> test1ModelFactory, Test2Model.Factory<T4> test2ModelFactory) {
       this.creator = creator;
       this.test1ModelFactory = test1ModelFactory;
       this.test2ModelFactory = test2ModelFactory;
@@ -143,7 +143,7 @@ public interface Test3Model {
 
     private final Test1Model.Factory<T2> test1ModelFactory;
 
-    private Custom_valueMapper(Custom_valueCreator<T1, T2, T> creator, Test2Model.Factory<T1> test2ModelFactory, Test1Model.Factory<T2> test1ModelFactory) {
+    Custom_valueMapper(Custom_valueCreator<T1, T2, T> creator, Test2Model.Factory<T1> test2ModelFactory, Test1Model.Factory<T2> test1ModelFactory) {
       this.creator = creator;
       this.test2ModelFactory = test2ModelFactory;
       this.test1ModelFactory = test1ModelFactory;
@@ -184,7 +184,7 @@ public interface Test3Model {
 
     private final Test1Model.Factory<T2> test1ModelFactory;
 
-    private Aliased_custom_valueMapper(Aliased_custom_valueCreator<T1, T2, T> creator, Test2Model.Factory<T1> test2ModelFactory, Test1Model.Factory<T2> test1ModelFactory) {
+    Aliased_custom_valueMapper(Aliased_custom_valueCreator<T1, T2, T> creator, Test2Model.Factory<T1> test2ModelFactory, Test1Model.Factory<T2> test1ModelFactory) {
       this.creator = creator;
       this.test2ModelFactory = test2ModelFactory;
       this.test1ModelFactory = test1ModelFactory;
@@ -225,7 +225,7 @@ public interface Test3Model {
 
     private final Test2Model.Factory<T5> test2ModelFactory;
 
-    private Aliased_tablesMapper(Aliased_tablesCreator<T1, T5, T> creator, Test1Model.Factory<T1> test1ModelFactory, Test2Model.Factory<T5> test2ModelFactory) {
+    Aliased_tablesMapper(Aliased_tablesCreator<T1, T5, T> creator, Test1Model.Factory<T1> test1ModelFactory, Test2Model.Factory<T5> test2ModelFactory) {
       this.creator = creator;
       this.test1ModelFactory = test1ModelFactory;
       this.test2ModelFactory = test2ModelFactory;

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
@@ -202,7 +202,7 @@ public interface HockeyPlayerModel {
 
     private final TeamModel.Factory<T11> teamModelFactory;
 
-    private Select_allMapper(Select_allCreator<T1, T11, T> creator, Factory<T1> hockeyPlayerModelFactory, TeamModel.Factory<T11> teamModelFactory) {
+    Select_allMapper(Select_allCreator<T1, T11, T> creator, Factory<T1> hockeyPlayerModelFactory, TeamModel.Factory<T11> teamModelFactory) {
       this.creator = creator;
       this.hockeyPlayerModelFactory = hockeyPlayerModelFactory;
       this.teamModelFactory = teamModelFactory;
@@ -253,7 +253,7 @@ public interface HockeyPlayerModel {
 
     private final TeamModel.Factory<T11> teamModelFactory;
 
-    private For_teamMapper(For_teamCreator<T1, T11, T> creator, Factory<T1> hockeyPlayerModelFactory, TeamModel.Factory<T11> teamModelFactory) {
+    For_teamMapper(For_teamCreator<T1, T11, T> creator, Factory<T1> hockeyPlayerModelFactory, TeamModel.Factory<T11> teamModelFactory) {
       this.creator = creator;
       this.hockeyPlayerModelFactory = hockeyPlayerModelFactory;
       this.teamModelFactory = teamModelFactory;
@@ -300,7 +300,7 @@ public interface HockeyPlayerModel {
   final class Subquery_joinMapper<T extends Subquery_joinModel> implements RowMapper<T> {
     private final Subquery_joinCreator<T> creator;
 
-    private Subquery_joinMapper(Subquery_joinCreator<T> creator) {
+    Subquery_joinMapper(Subquery_joinCreator<T> creator) {
       this.creator = creator;
     }
 
@@ -327,7 +327,7 @@ public interface HockeyPlayerModel {
   final class Select_expressionMapper<T extends Select_expressionModel> implements RowMapper<T> {
     private final Select_expressionCreator<T> creator;
 
-    private Select_expressionMapper(Select_expressionCreator<T> creator) {
+    Select_expressionMapper(Select_expressionCreator<T> creator) {
       this.creator = creator;
     }
 
@@ -356,7 +356,7 @@ public interface HockeyPlayerModel {
 
     private final Factory<T1> hockeyPlayerModelFactory;
 
-    private Expression_subqueryMapper(Expression_subqueryCreator<T1, T> creator, Factory<T1> hockeyPlayerModelFactory) {
+    Expression_subqueryMapper(Expression_subqueryCreator<T1, T> creator, Factory<T1> hockeyPlayerModelFactory) {
       this.creator = creator;
       this.hockeyPlayerModelFactory = hockeyPlayerModelFactory;
     }
@@ -399,7 +399,7 @@ public interface HockeyPlayerModel {
 
     private final TeamModel.Factory<T11> teamModelFactory;
 
-    private Some_joinMapper(Some_joinCreator<T1, T11, T> creator, Factory<T1> hockeyPlayerModelFactory, TeamModel.Factory<T11> teamModelFactory) {
+    Some_joinMapper(Some_joinCreator<T1, T11, T> creator, Factory<T1> hockeyPlayerModelFactory, TeamModel.Factory<T11> teamModelFactory) {
       this.creator = creator;
       this.hockeyPlayerModelFactory = hockeyPlayerModelFactory;
       this.teamModelFactory = teamModelFactory;
@@ -448,7 +448,7 @@ public interface HockeyPlayerModel {
   final class With_queryMapper<T extends With_queryModel> implements RowMapper<T> {
     private final With_queryCreator<T> creator;
 
-    private With_queryMapper(With_queryCreator<T> creator) {
+    With_queryMapper(With_queryCreator<T> creator) {
       this.creator = creator;
     }
 


### PR DESCRIPTION
Since they are always instantiated by the factory, the public/private distinction isn't needed and being non-private avoids a synthetic accessor method.