### PR TITLE
Use the absolute path of the failure file in gradle errors

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -120,7 +120,7 @@ open class SqlDelightTask : SourceTask() {
   }
 
   private fun Status.Failure.message(file: File) = "" +
-      "${file.name} " +
+      "${file.absolutePath} " +
       "line ${originatingElement.start.line}:${originatingElement.start.charPositionInLine}" +
       " - $errorMessage\n${detailText(originatingElement)}"
 


### PR DESCRIPTION
This is important for linking gradle errors to a specific file from the IDE, since files can have the same name in separate packages.