### PR TITLE
Enabled WITH RECURSIVE syntax

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/resolution/ExpressionResolver.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/resolution/ExpressionResolver.kt
@@ -35,7 +35,7 @@ internal fun Resolver.resolve(
 
   if (expression.column_name() != null) {
     // | ( ( database_name '.' )? table_name '.' )? column_name
-    return resolve(scopedValues, expression.column_name(), expression.table_name()) as? Value
+    return scopedResolve(scopedValues, expression.column_name(), expression.table_name()) as? Value
   } else if (expression.literal_value() != null) {
     try {
       return expression.literal_value().resolve(expression)

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/resolution/Resolver.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/resolution/Resolver.kt
@@ -88,8 +88,12 @@ data class Resolver(
      * expression select statement would fail with "no table named test1" but because
      * we scope in the current resolution (in this case the resolution of "test" aliased as test1)
      * it is able to resolve "test1.some_id".
+     *
+     * Each element in the list represents the values available at that scope level. In the above
+     * example the "test1" values will be at index 0 and "test2" values will be at index 1. During
+     * resolution, the closest scope is preferred when using a value.
      */
-    internal val scopedValues: List<Result> = emptyList(),
+    internal val scopedValues: List<List<Result>> = emptyList(),
 
     /**
      * The offset of an element we wish to know the source of. Note that if we ever change contexts
@@ -123,7 +127,7 @@ data class Resolver(
         symbolTable + SymbolTable(commonTable, commonTable)
       }))
 
-  internal fun withScopedValues(values: List<Result>) = copy(scopedValues = scopedValues + values)
+  internal fun withScopedValues(values: List<Result>) = copy(scopedValues = scopedValues + listOf(values))
 
   fun findElementAtCursor(element: ParserRuleContext?, source: ParserRuleContext?, elementToFind: Int?) {
     if (element != null && element.start.startIndex == elementToFind) {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/util/AntlrUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/util/AntlrUtil.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqldelight.util
+
+import com.squareup.sqldelight.SqliteParser
+
+internal fun SqliteParser.Common_table_expressionContext.isRecursive() =
+    (parent as SqliteParser.With_clauseContext).K_RECURSIVE() != null

--- a/sqldelight-gradle-plugin/src/test/fixtures/with-recursive/failure.txt
+++ b/sqldelight-gradle-plugin/src/test/fixtures/with-recursive/failure.txt
@@ -1,0 +1,31 @@
+Test.sq line 28:2 - Recursive subquery found: ancestor_of_alice -> ancestor_of_alice
+  24    with_clauses_errors:
+  25    WITH
+  26      parent_of(name, parent) AS
+  27        (SELECT name, mom FROM family UNION SELECT name, dad FROM family),
+  28      ancestor_of_alice(name) AS
+          ^^^^^^^^^^^^^^^^^
+  29        (SELECT parent FROM parent_of WHERE name='Alice'
+  30         UNION ALL
+  31         SELECT parent FROM parent_of JOIN ancestor_of_alice USING(name))
+  32    SELECT family.name FROM ancestor_of_alice, family
+  33     WHERE ancestor_of_alice.name=family.name
+  34       AND died IS NULL
+  35     ORDER BY born
+
+Test.sq line 31:63 - No column found with name name
+  24    with_clauses_errors:
+  25    WITH
+  26      parent_of(name, parent) AS
+  27        (SELECT name, mom FROM family UNION SELECT name, dad FROM family),
+  28      ancestor_of_alice(name) AS
+  29        (SELECT parent FROM parent_of WHERE name='Alice'
+  30         UNION ALL
+  31         SELECT parent FROM parent_of JOIN ancestor_of_alice USING(name))
+                                                                       ^^^^
+  32    SELECT family.name FROM ancestor_of_alice, family
+  33     WHERE ancestor_of_alice.name=family.name
+  34       AND died IS NULL
+  35     ORDER BY born
+
+2 errors

--- a/sqldelight-gradle-plugin/src/test/fixtures/with-recursive/src/main/sqldelight/com/sample/Test.sq
+++ b/sqldelight-gradle-plugin/src/test/fixtures/with-recursive/src/main/sqldelight/com/sample/Test.sq
@@ -1,0 +1,65 @@
+import java.util.Date;
+
+CREATE TABLE family(
+  name TEXT PRIMARY KEY,
+  mom TEXT REFERENCES family,
+  dad TEXT REFERENCES family,
+  born INTEGER as Date,
+  died INTEGER as Date
+);
+
+with_clauses:
+WITH RECURSIVE
+  parent_of(name, parent) AS
+    (SELECT name, mom FROM family UNION SELECT name, dad FROM family),
+  ancestor_of_alice(name) AS
+    (SELECT parent FROM parent_of WHERE name='Alice'
+     UNION ALL
+     SELECT parent FROM parent_of JOIN ancestor_of_alice USING(name))
+SELECT family.name FROM ancestor_of_alice, family
+ WHERE ancestor_of_alice.name=family.name
+   AND died IS NULL
+ ORDER BY born;
+
+with_clauses_errors:
+WITH
+  parent_of(name, parent) AS
+    (SELECT name, mom FROM family UNION SELECT name, dad FROM family),
+  ancestor_of_alice(name) AS
+    (SELECT parent FROM parent_of WHERE name='Alice'
+     UNION ALL
+     SELECT parent FROM parent_of JOIN ancestor_of_alice USING(name))
+SELECT family.name FROM ancestor_of_alice, family
+ WHERE ancestor_of_alice.name=family.name
+   AND died IS NULL
+ ORDER BY born;
+
+sudoku:
+WITH RECURSIVE
+  input(sud) AS (
+    VALUES('53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79')
+  ),
+  digits(z, lp) AS (
+    VALUES('1', 1)
+    UNION ALL SELECT
+    CAST(lp+1 AS TEXT), lp+1 FROM digits WHERE lp<9
+  ),
+  x(s, ind) AS (
+    SELECT sud, instr(sud, '.') FROM input
+    UNION ALL
+    SELECT
+      substr(s, 1, ind-1) || z || substr(s, ind+1),
+      instr( substr(s, 1, ind-1) || z || substr(s, ind+1), '.' )
+     FROM x, digits AS z
+    WHERE ind>0
+      AND NOT EXISTS (
+            SELECT 1
+              FROM digits AS lp
+             WHERE z.z = substr(s, ((ind-1)/9)*9 + lp, 1)
+                OR z.z = substr(s, ((ind-1)%9) + (lp-1)*9 + 1, 1)
+                OR z.z = substr(s, (((ind-1)/3) % 3) * 3
+                        + ((ind-1)/27) * 27 + lp
+                        + ((lp-1) / 3) * 6, 1)
+         )
+  )
+SELECT s FROM x WHERE ind=0;

--- a/sqldelight-gradle-plugin/src/test/fixtures/with-table-no-column/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/with-table-no-column/expected/com/sample/TestModel.java
@@ -1,0 +1,30 @@
+package com.sample;
+
+import android.database.Cursor;
+import com.squareup.sqldelight.RowMapper;
+import java.lang.Long;
+import java.lang.Override;
+import java.lang.String;
+
+public interface TestModel {
+  String SOME_SELECT = ""
+      + "WITH test (cheese) AS (\n"
+      + "  VALUES (1)\n"
+      + ")\n"
+      + "SELECT *\n"
+      + "FROM test";
+
+  final class Factory {
+    public Factory() {
+    }
+
+    public RowMapper<Long> some_selectMapper() {
+      return new RowMapper<Long>() {
+        @Override
+        public Long map(Cursor cursor) {
+          return cursor.getLong(0);
+        }
+      };
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/fixtures/with-table-no-column/failure.txt
+++ b/sqldelight-gradle-plugin/src/test/fixtures/with-table-no-column/failure.txt
@@ -1,8 +1,0 @@
-Test.sq line 2:11 - No column found with name cheese
-  1    some_select:
-  2    WITH test (cheese) AS (
-                  ^^^^^^
-  3      VALUES (1)
-  4    )
-  5    SELECT *
-  6    FROM test

--- a/sqldelight-studio-plugin/src/test/kotlin/com/squareup/sqldelight/completion/CompletionTests.kt
+++ b/sqldelight-studio-plugin/src/test/kotlin/com/squareup/sqldelight/completion/CompletionTests.kt
@@ -57,7 +57,7 @@ class CompletionTests : SqlDelightFixtureTestCase() {
   }
 
   fun testCommonTable() {
-    doTestVariants("common_table", "common_column")
+    doTestVariants("common_table", "common_column", "count")
   }
 
   fun testReferences() {

--- a/sqldelight-studio-plugin/src/test/kotlin/com/squareup/sqldelight/findusages/FindUsagesTests.kt
+++ b/sqldelight-studio-plugin/src/test/kotlin/com/squareup/sqldelight/findusages/FindUsagesTests.kt
@@ -51,8 +51,7 @@ class FindUsagesTests : SqlDelightFixtureTestCase() {
     myFixture.testFindUsages("$sqldelightDir/AliasedColumn.sq").assertThat()
         .hasElementAtCaret("testData/$fixtureDirectory/$sqldelightDir/AliasedColumn.sq", "caret")
         .hasElementAtCaret("testData/main/Test1.sq", "caret4")
-        .hasElementAtCaret("testData/main/Test1.sq", "caret12")
-        .hasSize(3)
+        .hasSize(2)
   }
 
   fun testCommonTable() {

--- a/sqldelight-studio-plugin/testData/completion/main/sqldelight/com/sample/CommonTable.sq
+++ b/sqldelight-studio-plugin/testData/completion/main/sqldelight/com/sample/CommonTable.sq
@@ -1,6 +1,6 @@
 some_select:
-WITH common_table (common_column) AS (
-  SELECT different_column2 AS common_column, count(*) AS count
+WITH common_table (common_column, count) AS (
+  SELECT different_column2, count(*)
   FROM test2
 )
 SELECT <caret>

--- a/sqldelight-studio-plugin/testData/main/Test1.sq
+++ b/sqldelight-studio-plugin/testData/main/Test1.sq
@@ -10,7 +10,7 @@ FROM <caret6>test1;
 
 view_with_common_table:
 CREATE VIEW <caret11>with_common_table AS
-WITH common_table (<caret12>aliased_column) AS (
+WITH common_table AS (
   SELECT <caret10>column1 AS <caret4>aliased_column
   FROM <caret7>test1
 )


### PR DESCRIPTION
Closes #417 

Notable bugs this uncovered:
 - When you specify common table columns it isn't doing a projection it's aliasing the existing columns.
 - If there are multiple possible columns for a column name expression it uses the closest scoped column.