### PR TITLE
Update the until build to new format

### DIFF
--- a/sqldelight-studio-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-studio-plugin/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
   <vendor url="https://github.com/square">Square, Inc.</vendor>
   <idea-version
       since-build="134.549"
-      until-build="145.9999"
+      until-build="145.*"
   />
   <depends>com.intellij.modules.lang</depends>
   <depends>org.jetbrains.android</depends>


### PR DESCRIPTION
Hoping this fixes the `NoClassDef` and `NoMethodDef` errors as well.