### PR TITLE
Drop limited table support which fixes autocompleting in updates

### DIFF
--- a/sqldelight-compiler/src/main/antlr/com/squareup/sqldelight/Sqlite.g4
+++ b/sqldelight-compiler/src/main/antlr/com/squareup/sqldelight/Sqlite.g4
@@ -57,7 +57,6 @@ sql_stmt
                                       | create_trigger_stmt
                                       | create_view_stmt
                                       | delete_stmt
-                                      | delete_stmt_limited
                                       | drop_index_stmt
                                       | drop_table_stmt
                                       | drop_trigger_stmt
@@ -69,7 +68,6 @@ sql_stmt
                                       | savepoint_stmt
                                       | select_stmt
                                       | update_stmt
-                                      | update_stmt_limited
                                       | vacuum_stmt )
  ;
 
@@ -114,14 +112,6 @@ create_view_stmt
 delete_stmt
  : with_clause? K_DELETE K_FROM table_name
    ( K_WHERE expr )?
- ;
-
-delete_stmt_limited
- : with_clause? K_DELETE K_FROM qualified_table_name 
-   ( K_WHERE expr )?
-   ( ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
-     K_LIMIT expr ( ( K_OFFSET | ',' ) expr )?
-   )?
  ;
 
 drop_index_stmt
@@ -204,18 +194,6 @@ update_stmt
                          | K_OR K_FAIL
                          | K_OR K_IGNORE )? table_name
    K_SET column_name '=' setter_expr ( ',' column_name '=' setter_expr )* ( K_WHERE expr )?
- ;
-
-update_stmt_limited
- : with_clause? K_UPDATE ( K_OR K_ROLLBACK
-                         | K_OR K_ABORT
-                         | K_OR K_REPLACE
-                         | K_OR K_FAIL
-                         | K_OR K_IGNORE )? qualified_table_name
-   K_SET column_name '=' setter_expr ( ',' column_name '=' setter_expr )* ( K_WHERE expr )?
-   ( ( K_ORDER K_BY ordering_term ( ',' ordering_term )* )?
-     K_LIMIT expr ( ( K_OFFSET | ',' ) expr )? 
-   )?
  ;
 
 vacuum_stmt

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/validation/DeleteValidator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/validation/DeleteValidator.kt
@@ -26,28 +26,6 @@ internal class DeleteValidator(
     val resolver: Resolver,
     val scopedValues: List<Result> = emptyList()
 ) {
-  fun validate(delete: SqliteParser.Delete_stmt_limitedContext) {
-    val resolution = listOf(resolver.resolve(delete.qualified_table_name().table_name()))
-        .filterNotNull()
-
-    val resolver: Resolver
-    if (delete.with_clause() != null) {
-      try {
-        resolver = this.resolver.withResolver(delete.with_clause())
-      } catch (e: SqlitePluginException) {
-        resolver = this.resolver
-        resolver.errors.add(ResolutionError.WithTableError(e.originatingElement, e.message))
-      }
-    } else {
-      resolver = this.resolver
-    }
-
-    val scopedResolver = resolver.withScopedValues(scopedValues + resolution)
-    delete.ordering_term().map { it.expr() }.plus(delete.expr()).forEach {
-      scopedResolver.resolve(it, false)
-    }
-  }
-
   fun validate(delete: SqliteParser.Delete_stmtContext) {
     val resolution = listOf(resolver.resolve(delete.table_name())).filterNotNull()
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/validation/SqlDelightValidator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/validation/SqlDelightValidator.kt
@@ -134,9 +134,7 @@ class SqlDelightValidator {
       select_stmt()?.apply { resolver.resolve(this) }
       insert_stmt()?.apply { InsertValidator(resolver).validate(this) }
       update_stmt()?.apply { UpdateValidator(resolver).validate(this) }
-      update_stmt_limited()?.apply { UpdateValidator(resolver).validate(this) }
       delete_stmt()?.apply { DeleteValidator(resolver).validate(this) }
-      delete_stmt_limited()?.apply { DeleteValidator(resolver).validate(this) }
       create_index_stmt()?.apply { CreateIndexValidator(resolver).validate(this) }
       create_trigger_stmt()?.apply { CreateTriggerValidator(resolver).validate(this) }
       create_view_stmt()?.apply { resolver.resolve(select_stmt()) }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/validation/UpdateValidator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/validation/UpdateValidator.kt
@@ -26,28 +26,6 @@ internal class UpdateValidator(
     val resolver: Resolver,
     val scopedValues: List<Result> = emptyList()
 ) {
-  fun validate(update: SqliteParser.Update_stmt_limitedContext) {
-    val resolution = listOf(resolver.resolve(update.qualified_table_name().table_name())).filterNotNull()
-    update.column_name().forEach { resolver.resolve(resolution, it) }
-
-    var resolver: Resolver
-    if (update.with_clause() != null) {
-      try {
-        resolver = this.resolver.withResolver(update.with_clause())
-      } catch (e: SqlitePluginException) {
-        resolver = this.resolver
-        resolver.errors.add(ResolutionError.WithTableError(e.originatingElement, e.message))
-      }
-    } else {
-      resolver = this.resolver
-    }
-
-    resolver = resolver.withScopedValues(scopedValues + resolution)
-    update.expr().forEach { resolver.resolve(it, false) }
-    update.setter_expr().map { it.expr() }.filterNotNull().forEach { resolver.resolve(it) }
-    update.ordering_term().forEach { resolver.resolve(it.expr(), false) }
-  }
-
   fun validate(update: SqliteParser.Update_stmtContext) {
     val resolution = listOf(resolver.resolve(update.table_name())).filterNotNull()
     update.column_name().forEach { resolver.resolve(resolution, it) }

--- a/sqldelight-gradle-plugin/src/test/fixtures/timestamp-literals/failure.txt
+++ b/sqldelight-gradle-plugin/src/test/fixtures/timestamp-literals/failure.txt
@@ -1,1 +1,1 @@
-Test.sq line 28:14 - no viable alternative at input 'UPDATE test\nSET date1 = CURRENT_TIMESTAMP,\n    date2 = CURRENT_TIME,\n    date3 = CURRENT_TIMESTAMP\nWHERE date1 > CURRENT_TIME'
+Test.sq line 28:14 - mismatched input 'CURRENT_TIME' expecting {':', '(', '+', '-', '~', K_CASE, K_CAST, K_EXISTS, K_NOT, K_NULL, K_RAISE, IDENTIFIER, INTEGER_LITERAL, REAL_LITERAL, BIND_DIGITS, STRING_LITERAL, BLOB_LITERAL}

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-validation-failures/failure.txt
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-validation-failures/failure.txt
@@ -17,12 +17,4 @@ Test.sq line 18:6 - No column found with name fake_column
   18    WHERE fake_column = 2
               ^^^^^^^^^^^
 
-Test.sq line 23:9 - No column found with name fake_column
-  20    update_3:
-  21    UPDATE test
-  22    SET some_column = 2
-  23    ORDER BY fake_column
-                 ^^^^^^^^^^^
-  24    LIMIT 3
-
-3 errors
+2 errors

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-validation-failures/src/main/sqldelight/com/sample/Test.sq
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-validation-failures/src/main/sqldelight/com/sample/Test.sq
@@ -16,9 +16,3 @@ SET some_column = (
   SELECT total_count FROM temp_table
 )
 WHERE fake_column = 2;
-
-update_3:
-UPDATE test
-SET some_column = 2
-ORDER BY fake_column
-LIMIT 3;

--- a/sqldelight-studio-plugin/src/test/kotlin/com/squareup/sqldelight/completion/CompletionTests.kt
+++ b/sqldelight-studio-plugin/src/test/kotlin/com/squareup/sqldelight/completion/CompletionTests.kt
@@ -24,6 +24,10 @@ class CompletionTests : SqlDelightFixtureTestCase() {
     doTestVariants("different_view", "test1", "view1", "test2", "with_common_table")
   }
 
+  fun testUpdateTableName() {
+    doTestVariants("different_view", "test1", "view1", "test2", "with_common_table")
+  }
+
   fun testResultColumn() {
     doTestVariants("column1", "test1", "`quoted_identifier`")
   }

--- a/sqldelight-studio-plugin/testData/completion/main/sqldelight/com/sample/UpdateTableName.sq
+++ b/sqldelight-studio-plugin/testData/completion/main/sqldelight/com/sample/UpdateTableName.sq
@@ -1,0 +1,2 @@
+some_update
+UPDATE <caret>


### PR DESCRIPTION
Close #443 

Delete/Update limited aren't available on stock android sqlite anyways, you would have to compile yourself with a specific compiler flag. 