### PR TITLE
Fix an error where join was unscoping variables before validating the constraint clause

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/resolution/JoinResolver.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/resolution/JoinResolver.kt
@@ -54,7 +54,7 @@ internal fun Resolver.resolve(
     } else {
       localResponse = resolve(table, recursiveCommonTable)
     }
-    errors.addAll(JoinValidator(this, localResponse, response + scopedValues.flatMap { it })
+    errors.addAll(JoinValidator(this, localResponse, scopedValues.plus<List<Result>>(response))
         .validate(joinClause.first))
     response += localResponse
   }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/resolution/Resolver.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/resolution/Resolver.kt
@@ -129,6 +129,8 @@ data class Resolver(
 
   internal fun withScopedValues(values: List<Result>) = copy(scopedValues = scopedValues + listOf(values))
 
+  internal fun withValues(values: List<List<Result>>) = copy(scopedValues = scopedValues + values)
+
   fun findElementAtCursor(element: ParserRuleContext?, source: ParserRuleContext?, elementToFind: Int?) {
     if (element != null && element.start.startIndex == elementToFind) {
       elementFound.set(source)

--- a/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/FolderModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/FolderModel.java
@@ -1,0 +1,88 @@
+package com.sample;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.squareup.sqldelight.RowMapper;
+import java.lang.Override;
+import java.lang.String;
+
+public interface FolderModel {
+  String TABLE_NAME = "folder";
+
+  String FID = "fid";
+
+  String TOTAL_COUNTER = "total_counter";
+
+  String CREATE_TABLE = ""
+      + "CREATE TABLE folder (\n"
+      + "    fid INTEGER PRIMARY KEY NOT NULL,\n"
+      + "    total_counter INTEGER NOT NULL\n"
+      + ")";
+
+  long fid();
+
+  int total_counter();
+
+  interface Creator<T extends FolderModel> {
+    T create(long fid, int total_counter);
+  }
+
+  final class Mapper<T extends FolderModel> implements RowMapper<T> {
+    private final Factory<T> folderModelFactory;
+
+    public Mapper(Factory<T> folderModelFactory) {
+      this.folderModelFactory = folderModelFactory;
+    }
+
+    @Override
+    public T map(@NonNull Cursor cursor) {
+      return folderModelFactory.creator.create(
+          cursor.getLong(0),
+          cursor.getInt(1)
+      );
+    }
+  }
+
+  final class Marshal {
+    protected final ContentValues contentValues = new ContentValues();
+
+    Marshal(@Nullable FolderModel copy) {
+      if (copy != null) {
+        this.fid(copy.fid());
+        this.total_counter(copy.total_counter());
+      }
+    }
+
+    public ContentValues asContentValues() {
+      return contentValues;
+    }
+
+    public Marshal fid(long fid) {
+      contentValues.put(FID, fid);
+      return this;
+    }
+
+    public Marshal total_counter(int total_counter) {
+      contentValues.put(TOTAL_COUNTER, total_counter);
+      return this;
+    }
+  }
+
+  final class Factory<T extends FolderModel> {
+    public final Creator<T> creator;
+
+    public Factory(Creator<T> creator) {
+      this.creator = creator;
+    }
+
+    public Marshal marshal() {
+      return new Marshal(null);
+    }
+
+    public Marshal marshal(FolderModel copy) {
+      return new Marshal(copy);
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/MessageModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/MessageModel.java
@@ -1,0 +1,99 @@
+package com.sample;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.squareup.sqldelight.RowMapper;
+import java.lang.Override;
+import java.lang.String;
+
+public interface MessageModel {
+  String TABLE_NAME = "message";
+
+  String MID = "mid";
+
+  String FID = "fid";
+
+  String CREATE_TABLE = ""
+      + "CREATE TABLE message (\n"
+      + "    mid         INTEGER PRIMARY KEY NOT NULL,\n"
+      + "    fid         INTEGER NOT NULL\n"
+      + ")";
+
+  String DELETE_ORPHANS = ""
+      + "DELETE FROM folder WHERE folder.fid IN (\n"
+      + "  SELECT folder.fid FROM folder\n"
+      + "  LEFT JOIN message ON message.fid=folder.fid\n"
+      + ")";
+
+  String DELETE_ORPHANS_2 = ""
+      + "DELETE FROM folder WHERE folder.fid IN (\n"
+      + "  SELECT folder.fid FROM folder WHERE fid = fid\n"
+      + ")";
+
+  long mid();
+
+  long fid();
+
+  interface Creator<T extends MessageModel> {
+    T create(long mid, long fid);
+  }
+
+  final class Mapper<T extends MessageModel> implements RowMapper<T> {
+    private final Factory<T> messageModelFactory;
+
+    public Mapper(Factory<T> messageModelFactory) {
+      this.messageModelFactory = messageModelFactory;
+    }
+
+    @Override
+    public T map(@NonNull Cursor cursor) {
+      return messageModelFactory.creator.create(
+          cursor.getLong(0),
+          cursor.getLong(1)
+      );
+    }
+  }
+
+  final class Marshal {
+    protected final ContentValues contentValues = new ContentValues();
+
+    Marshal(@Nullable MessageModel copy) {
+      if (copy != null) {
+        this.mid(copy.mid());
+        this.fid(copy.fid());
+      }
+    }
+
+    public ContentValues asContentValues() {
+      return contentValues;
+    }
+
+    public Marshal mid(long mid) {
+      contentValues.put(MID, mid);
+      return this;
+    }
+
+    public Marshal fid(long fid) {
+      contentValues.put(FID, fid);
+      return this;
+    }
+  }
+
+  final class Factory<T extends MessageModel> {
+    public final Creator<T> creator;
+
+    public Factory(Creator<T> creator) {
+      this.creator = creator;
+    }
+
+    public Marshal marshal() {
+      return new Marshal(null);
+    }
+
+    public Marshal marshal(MessageModel copy) {
+      return new Marshal(copy);
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/src/main/sqldelight/com/sample/Folder.sq
+++ b/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/src/main/sqldelight/com/sample/Folder.sq
@@ -1,0 +1,4 @@
+CREATE TABLE folder (
+    fid INTEGER PRIMARY KEY NOT NULL,
+    total_counter INTEGER AS Integer NOT NULL
+);

--- a/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/src/main/sqldelight/com/sample/Message.sq
+++ b/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/src/main/sqldelight/com/sample/Message.sq
@@ -1,0 +1,15 @@
+CREATE TABLE message (
+    mid         INTEGER PRIMARY KEY NOT NULL,
+    fid         INTEGER NOT NULL
+);
+
+delete_orphans:
+DELETE FROM folder WHERE folder.fid IN (
+  SELECT folder.fid FROM folder
+  LEFT JOIN message ON message.fid=folder.fid
+);
+
+delete_orphans_2:
+DELETE FROM folder WHERE folder.fid IN (
+  SELECT folder.fid FROM folder WHERE fid = fid
+);


### PR DESCRIPTION
Fixes #447 

Join validation was improperly unscoping result columns from the left table and treating it as a flat table (with potentially ambiguous columns). The change in `JoinResolver` reverses that (gets rid of the flatmap)