### PR TITLE
Update to support-annotations to 24.2.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ ext {
 
   dep = [
     androidPlugin: 'com.android.tools.build:gradle:2.1.3',
-    supportAnnotations: 'com.android.support:support-annotations:24.2.0',
+    supportAnnotations: 'com.android.support:support-annotations:24.2.1',
     antlr: "org.antlr:antlr4:$antlrVersion",
     antlrRuntime: "org.antlr:antlr4-runtime:$antlrVersion",
     javaPoet: 'com.squareup:javapoet:1.7.0',


### PR DESCRIPTION
Google "accidentally" deleted 24.2.0 in the latest version.