### PR TITLE
Add back in the ability to create SqlDelightStatements for insert/update/deletes

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/FactorySpec.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/FactorySpec.kt
@@ -58,6 +58,8 @@ internal class FactorySpec(
           .addMethod(MethodSpec.methodBuilder(MARSHAL_METHOD)
               .addModifiers(Modifier.PUBLIC)
               .returns(marshalClassName)
+              .addAnnotation(ClassName.get("java.lang", "Deprecated"))
+              .addJavadoc("@deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)\n")
               .addStatement(
                   "return new \$T(\$L)",
                   marshalClassName,
@@ -70,6 +72,8 @@ internal class FactorySpec(
               .addModifiers(Modifier.PUBLIC)
               .returns(marshalClassName)
               .addParameter(ParameterSpec.builder(table.javaType, COPY_PARAM).build())
+              .addAnnotation(ClassName.get("java.lang", "Deprecated"))
+              .addJavadoc("@deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)\n")
               .addStatement(
                   "return new \$T(\$L)",
                   marshalClassName,
@@ -80,7 +84,7 @@ internal class FactorySpec(
               .build())
     }
 
-    sqlStmts.filter { it.needsConstant }.forEach {
+    sqlStmts.forEach {
       typeSpec.addMethod(it.factoryStatementMethod(interfaceType, table != null))
     }
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/model/SqlStmt.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/model/SqlStmt.kt
@@ -219,6 +219,11 @@ class SqlStmt private constructor(
         .addModifiers(Modifier.PUBLIC)
         .returns(SQLDELIGHT_STATEMENT)
 
+    if (!needsConstant) {
+      method.addAnnotation(ClassName.get("java.lang", "Deprecated"))
+        .addJavadoc("@deprecated Use {@link $programName}\n")
+    }
+
     if (addFactories) {
       // The first arguments to the method will be any foreign factories needed.
       arguments.map { it.argumentType.comparable }

--- a/sqldelight-gradle-plugin/src/test/fixtures/bind-object/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/bind-object/expected/com/sample/TestModel.java
@@ -9,6 +9,7 @@ import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
 import com.squareup.sqldelight.SqlDelightStatement;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Float;
 import java.lang.IllegalArgumentException;
@@ -84,10 +85,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }
@@ -105,6 +114,27 @@ public interface TestModel {
       }
       query.append("\n"
               + "FROM test");
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+    }
+
+    /**
+     * @deprecated Use {@link Some_delete}
+     */
+    @Deprecated
+    public SqlDelightStatement some_delete(Object arg1) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("WITH rubbish AS (VALUES (");
+      if (!(arg1 instanceof String)) {
+        query.append(arg1);
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add((String) arg1);
+      }
+      query.append("))\n"
+              + "DELETE FROM test\n"
+              + "WHERE _id IN rubbish");
       return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
     }
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/case-expression-type/expected/com/test/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/case-expression-type/expected/com/test/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -84,10 +85,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/cast-as-text/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/cast-as-text/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -97,10 +98,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/column-annotations/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/column-annotations/expected/com/sample/TestModel.java
@@ -160,10 +160,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/column-casing/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/column-casing/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -138,10 +139,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/create-trigger-duplicate-column/expected/com/sample/SimpleTableModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/create-trigger-duplicate-column/expected/com/sample/SimpleTableModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -94,10 +95,18 @@ public interface SimpleTableModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(SimpleTableModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/expected/com/test/UserModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -96,10 +97,18 @@ public interface UserModel {
       this.balance_nullableAdapter = balance_nullableAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, balanceAdapter, balance_nullableAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(UserModel copy) {
       return new Marshal(copy, balanceAdapter, balance_nullableAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/duplicate-result-column-name/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/duplicate-result-column-name/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -96,10 +97,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/duplicate-view-result-column-names/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/duplicate-view-result-column-names/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -101,10 +102,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/ForeignTableModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/ForeignTableModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -89,10 +90,18 @@ public interface ForeignTableModel {
       this.test_enumAdapter = test_enumAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, test_enumAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(ForeignTableModel copy) {
       return new Marshal(copy, test_enumAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/TestModel.java
@@ -9,6 +9,7 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -211,10 +212,18 @@ public interface TestModel {
       this.enum_value_intAdapter = enum_value_intAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, enum_valueAdapter, enum_value_intAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy, enum_valueAdapter, enum_value_intAdapter);
     }
@@ -345,6 +354,69 @@ public interface TestModel {
         query.append('?').append(arg1Index);
       }
       query.append(" || '2'");
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+    }
+
+    /**
+     * @deprecated Use {@link Insert_statement}
+     */
+    @Deprecated
+    public SqlDelightStatement insert_statement(@Nullable Test.TestEnum enum_value, @Nullable Test.TestEnum enum_value_int, @Nullable Long foreign_key) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("INSERT INTO test (enum_value, enum_value_int, foreign_key)\n"
+              + "VALUES (");
+      if (enum_value == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add((String) enum_valueAdapter.encode(enum_value));
+      }
+      query.append(", ");
+      if (enum_value_int == null) {
+        query.append("null");
+      } else {
+        query.append(enum_value_intAdapter.encode(enum_value_int));
+      }
+      query.append(", ");
+      if (foreign_key == null) {
+        query.append("null");
+      } else {
+        query.append(foreign_key);
+      }
+      query.append(")");
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+    }
+
+    /**
+     * @deprecated Use {@link Update_with_foreign}
+     */
+    @Deprecated
+    public SqlDelightStatement update_with_foreign(ForeignTableModel.Factory foreignTableModelFactory, @Nullable Test.TestEnum enum_value_int, @Nullable Test.TestEnum test_enum) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("UPDATE test\n"
+              + "SET enum_value_int = ");
+      if (enum_value_int == null) {
+        query.append("null");
+      } else {
+        query.append(enum_value_intAdapter.encode(enum_value_int));
+      }
+      query.append("\n"
+              + "WHERE foreign_key IN (\n"
+              + "  SELECT _id\n"
+              + "  FROM foreign_table\n"
+              + "  WHERE test_enum = ");
+      if (test_enum == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add((String) foreignTableModelFactory.test_enumAdapter.encode(test_enum));
+      }
+      query.append("\n"
+              + ")");
       return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
     }
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/expression-like/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/expression-like/expected/com/sample/TestModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
@@ -133,10 +134,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/function-nullability/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/function-nullability/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -270,10 +271,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -233,10 +234,18 @@ public interface Test1Model {
       this.column2Adapter = column2Adapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, column2Adapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(Test1Model copy) {
       return new Marshal(copy, column2Adapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -503,10 +504,18 @@ public interface Test2Model {
       this.column2Adapter = column2Adapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, column2Adapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(Test2Model copy) {
       return new Marshal(copy, column2Adapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/individual_table_columns/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/individual_table_columns/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -255,10 +256,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/insert-default-values/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/insert-default-values/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -81,10 +82,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/javadoc/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/javadoc/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -121,10 +122,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/keyword_identifiers/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/keyword_identifiers/expected/com/sample/TestModel.java
@@ -8,9 +8,14 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
+import com.squareup.sqldelight.SqlDelightStatement;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public interface TestModel {
@@ -174,12 +179,67 @@ public interface TestModel {
       this.TEXTAdapter = TEXTAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, TEXTAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy, TEXTAdapter);
+    }
+
+    /**
+     * @deprecated Use {@link Insert_stmt}
+     */
+    @Deprecated
+    public SqlDelightStatement insert_stmt(@Nullable String ASC, @Nullable String DESC, @Nullable List TEXT, @Nullable Boolean Boolean, @Nullable String new_) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("INSERT INTO test('ASC', \"DESC\", `TEXT`, [Boolean], new)\n"
+              + "VALUES (");
+      if (ASC == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(ASC);
+      }
+      query.append(", ");
+      if (DESC == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(DESC);
+      }
+      query.append(", ");
+      if (TEXT == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add((String) TEXTAdapter.encode(TEXT));
+      }
+      query.append(", ");
+      if (Boolean == null) {
+        query.append("null");
+      } else {
+        query.append(Boolean ? 1 : 0);
+      }
+      query.append(", ");
+      if (new_ == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(new_);
+      }
+      query.append(")");
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
     }
 
     public Mapper<T> some_selectMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableAModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableAModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Integer;
 import java.lang.Long;
 import java.lang.Override;
@@ -148,10 +149,18 @@ public interface TableAModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TableAModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableBModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableBModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -91,10 +92,18 @@ public interface TableBModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TableBModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/sample/Test1Model.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.test.Test2Model;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -138,10 +139,18 @@ public interface Test1Model {
       this.dateAdapter = dateAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, dateAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(Test1Model copy) {
       return new Marshal(copy, dateAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/test/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/test/Test2Model.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.sample.Test1Model;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -113,10 +114,18 @@ public interface Test2Model {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(Test2Model copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test1Model.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -288,10 +289,18 @@ public interface Test1Model {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(Test1Model copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test2Model.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -307,10 +308,18 @@ public interface Test2Model {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(Test2Model copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullable-boolean/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullable-boolean/expected/com/test/UserModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -71,10 +72,18 @@ public interface UserModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(UserModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullable-enum/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullable-enum/expected/com/test/UserModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -77,10 +78,18 @@ public interface UserModel {
       this.genderAdapter = genderAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, genderAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(UserModel copy) {
       return new Marshal(copy, genderAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/scoped-table-resolution/expected/com/test/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/scoped-table-resolution/expected/com/test/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -89,10 +90,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -88,10 +89,18 @@ public interface TestModel {
       this.dateAdapter = dateAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, dateAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy, dateAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/sql-types-to-java-types/expected/com/test/TypeModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/sql-types-to-java-types/expected/com/test/TypeModel.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Float;
 import java.lang.Integer;
@@ -720,10 +721,18 @@ public interface TypeModel {
       this.b_as_custom_not_nullAdapter = b_as_custom_not_nullAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, i_as_doubleAdapter, i_as_double_not_nullAdapter, i_as_customAdapter, i_as_custom_not_nullAdapter, r_as_intAdapter, r_as_int_not_nullAdapter, r_as_customAdapter, r_as_custom_not_nullAdapter, t_as_longAdapter, t_as_long_not_nullAdapter, t_as_customAdapter, t_as_custom_not_nullAdapter, b_as_stringAdapter, b_as_string_not_nullAdapter, b_as_customAdapter, b_as_custom_not_nullAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TypeModel copy) {
       return new Marshal(copy, i_as_doubleAdapter, i_as_double_not_nullAdapter, i_as_customAdapter, i_as_custom_not_nullAdapter, r_as_intAdapter, r_as_int_not_nullAdapter, r_as_customAdapter, r_as_custom_not_nullAdapter, t_as_longAdapter, t_as_long_not_nullAdapter, t_as_customAdapter, t_as_custom_not_nullAdapter, b_as_stringAdapter, b_as_string_not_nullAdapter, b_as_customAdapter, b_as_custom_not_nullAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/sqlite-keyword-java-package/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/sqlite-keyword-java-package/expected/com/sample/TestModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import no.test.TestEnum;
@@ -78,10 +79,18 @@ public interface TestModel {
       this.test_columnAdapter = test_columnAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, test_columnAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy, test_columnAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/statement-bind-args/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/statement-bind-args/expected/com/sample/TestModel.java
@@ -8,9 +8,15 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
+import com.squareup.sqldelight.SqlDelightStatement;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -122,12 +128,78 @@ public interface TestModel {
       this.some_enumAdapter = some_enumAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, some_enumAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy, some_enumAdapter);
+    }
+
+    /**
+     * @deprecated Use {@link Insert_new_row}
+     */
+    @Deprecated
+    public SqlDelightStatement insert_new_row(@Nullable Boolean some_bool, @Nullable Test.TestEnum some_enum, @Nullable byte[] some_blob) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("INSERT INTO test (some_bool, some_enum, some_blob)\n"
+              + "VALUES (");
+      if (some_bool == null) {
+        query.append("null");
+      } else {
+        query.append(some_bool ? 1 : 0);
+      }
+      query.append(", ");
+      if (some_enum == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add((String) some_enumAdapter.encode(some_enum));
+      }
+      query.append(", ");
+      if (some_blob == null) {
+        query.append("null");
+      } else {
+        query.append(some_blob);
+      }
+      query.append(")");
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+    }
+
+    /**
+     * @deprecated Use {@link Trigger_stuff}
+     */
+    @Deprecated
+    public SqlDelightStatement trigger_stuff(@Nullable Boolean some_bool, long arg2) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("CREATE TRIGGER some_trigger\n"
+              + "BEFORE UPDATE ON test\n"
+              + "BEGIN\n"
+              + "  UPDATE test\n"
+              + "  SET some_bool = ");
+      if (some_bool == null) {
+        query.append("null");
+      } else {
+        query.append(some_bool ? 1 : 0);
+      }
+      query.append("\n"
+              + "  WHERE ");
+      query.append(arg2);
+      query.append(";\n"
+              + "END");
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
     }
   }
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/string-array-arg/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/string-array-arg/expected/com/sample/TestModel.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
@@ -101,10 +102,18 @@ public interface TestModel {
       this.some_enumAdapter = some_enumAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, some_enumAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy, some_enumAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/FolderModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/FolderModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -77,10 +78,18 @@ public interface FolderModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(FolderModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/MessageModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/MessageModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -88,10 +89,18 @@ public interface MessageModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(MessageModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/sum-uses-int/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/sum-uses-int/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Long;
 import java.lang.Override;
@@ -103,10 +104,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test1Model.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -65,10 +66,18 @@ public interface Test1Model {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(Test1Model copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test2Model.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
@@ -107,10 +108,18 @@ public interface Test2Model {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(Test2Model copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/trigger-raise/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/trigger-raise/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -70,10 +71,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/union-adopts-type/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/union-adopts-type/expected/com/sample/TestModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -341,10 +342,18 @@ public interface TestModel {
       this.custom_typeAdapter = custom_typeAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, custom_typeAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy, custom_typeAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-bind-array/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-bind-array/expected/com/sample/TestModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
@@ -88,10 +89,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-expression-has-columns/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-expression-has-columns/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -84,10 +85,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-inner-select/expected/com/sample/FolderModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-inner-select/expected/com/sample/FolderModel.java
@@ -7,8 +7,14 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
+import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public interface FolderModel {
   String TABLE_NAME = "folder";
@@ -79,12 +85,35 @@ public interface FolderModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(FolderModel copy) {
       return new Marshal(copy);
+    }
+
+    /**
+     * @deprecated Use {@link Update_total_counter_by_fid}
+     */
+    @Deprecated
+    public SqlDelightStatement update_total_counter_by_fid(long fid) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("UPDATE folder SET\n"
+              + "total_counter = (SELECT COUNT(*) FROM message WHERE folder.fid=message.fid)\n"
+              + "WHERE folder.fid = ");
+      query.append(fid);
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("folder"));
     }
   }
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-inner-select/expected/com/sample/MessageModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-inner-select/expected/com/sample/MessageModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -77,10 +78,18 @@ public interface MessageModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(MessageModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-where-bind/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-where-bind/expected/com/sample/TestModel.java
@@ -7,8 +7,14 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
+import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.StringBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public interface TestModel {
   String TABLE_NAME = "test_table";
@@ -197,12 +203,176 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
+    }
+
+    /**
+     * @deprecated Use {@link Update_row}
+     */
+    @Deprecated
+    public SqlDelightStatement update_row(@NonNull String column2, @Nullable String column3, @Nullable String column4, @Nullable String column5, @Nullable String column6, @Nullable byte[] column7, long column8, @NonNull String column9, @Nullable String column11, @NonNull String column1) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("UPDATE test_table\n"
+              + "SET column2 = ");
+      query.append('?').append(currentIndex++);
+      args.add(column2);
+      query.append(",\n"
+              + "    column3 = ");
+      if (column3 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column3);
+      }
+      query.append(",\n"
+              + "    column4 = ");
+      if (column4 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column4);
+      }
+      query.append(",\n"
+              + "    column5 = ");
+      if (column5 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column5);
+      }
+      query.append(",\n"
+              + "    column6 = ");
+      if (column6 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column6);
+      }
+      query.append(",\n"
+              + "    column7 = ");
+      if (column7 == null) {
+        query.append("null");
+      } else {
+        query.append(column7);
+      }
+      query.append(",\n"
+              + "    column8 = ");
+      query.append(column8);
+      query.append(",\n"
+              + "    column9 = ");
+      query.append('?').append(currentIndex++);
+      args.add(column9);
+      query.append(",\n"
+              + "    column11 = ");
+      if (column11 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column11);
+      }
+      query.append("\n"
+              + "WHERE column1 = ");
+      query.append('?').append(currentIndex++);
+      args.add(column1);
+      query.append("\n"
+              + "AND column7 < ");
+      query.append(column8);
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test_table"));
+    }
+
+    /**
+     * @deprecated Use {@link Update_row_with_name}
+     */
+    @Deprecated
+    public SqlDelightStatement update_row_with_name(@NonNull String column2, @Nullable String column3, @Nullable String column4, @Nullable String column5, @Nullable String column6, @Nullable byte[] column7, long column8, @NonNull String column9, @Nullable String column11, @NonNull String column1) {
+      List<String> args = new ArrayList<String>();
+      int currentIndex = 1;
+      StringBuilder query = new StringBuilder();
+      query.append("UPDATE test_table\n"
+              + "SET column2 = ");
+      query.append('?').append(currentIndex++);
+      args.add(column2);
+      query.append(",\n"
+              + "    column3 = ");
+      if (column3 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column3);
+      }
+      query.append(",\n"
+              + "    column4 = ");
+      if (column4 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column4);
+      }
+      query.append(",\n"
+              + "    column5 = ");
+      if (column5 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column5);
+      }
+      query.append(",\n"
+              + "    column6 = ");
+      if (column6 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column6);
+      }
+      query.append(",\n"
+              + "    column7 = ");
+      if (column7 == null) {
+        query.append("null");
+      } else {
+        query.append(column7);
+      }
+      query.append(",\n"
+              + "    column8 = ");
+      query.append(column8);
+      query.append(",\n"
+              + "    column9 = ");
+      query.append('?').append(currentIndex++);
+      args.add(column9);
+      query.append(",\n"
+              + "    column11 = ");
+      if (column11 == null) {
+        query.append("null");
+      } else {
+        query.append('?').append(currentIndex++);
+        args.add(column11);
+      }
+      query.append("\n"
+              + "WHERE column1 = ");
+      query.append('?').append(currentIndex++);
+      args.add(column1);
+      query.append("\n"
+              + "AND column7 < ");
+      if (column7 == null) {
+        query.append("null");
+      } else {
+        query.append(column7);
+      }
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test_table"));
     }
   }
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/use-adapter-from-factory/expected/com/sample/BookModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/use-adapter-from-factory/expected/com/sample/BookModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -112,10 +113,18 @@ public interface BookModel {
       this.published_atAdapter = published_atAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, published_atAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(BookModel copy) {
       return new Marshal(copy, published_atAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-preserves-type/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-preserves-type/expected/com/sample/TestModel.java
@@ -5,6 +5,7 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -138,10 +139,18 @@ public interface TestModel {
       this.creator = creator;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TestModel copy) {
       return new Marshal(copy);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
@@ -605,10 +606,18 @@ public interface HockeyPlayerModel {
       this.positionAdapter = positionAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, birth_dateAdapter, shootsAdapter, positionAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(HockeyPlayerModel copy) {
       return new Marshal(copy, birth_dateAdapter, shootsAdapter, positionAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/TeamModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/TeamModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
@@ -143,10 +144,18 @@ public interface TeamModel {
       this.foundedAdapter = foundedAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, foundedAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(TeamModel copy) {
       return new Marshal(copy, foundedAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/expected/com/test/UserModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -141,10 +142,18 @@ public interface UserModel {
       this.genderAdapter = genderAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, genderAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(UserModel copy) {
       return new Marshal(copy, genderAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine/expected/com/test/UserModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Float;
 import java.lang.Integer;
 import java.lang.Override;
@@ -260,10 +261,18 @@ public interface UserModel {
       this.such_listAdapter = such_listAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, genderAdapter, some_genericAdapter, some_listAdapter, gender2Adapter, full_userAdapter, such_listAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(UserModel copy) {
       return new Marshal(copy, genderAdapter, some_genericAdapter, some_listAdapter, gender2Adapter, full_userAdapter, such_listAdapter);
     }

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-for-kotlin/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-for-kotlin/expected/com/test/UserModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -141,10 +142,18 @@ public interface UserModel {
       this.genderAdapter = genderAdapter;
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal() {
       return new Marshal(null, genderAdapter);
     }
 
+    /**
+     * @deprecated Use compiled statements (https://github.com/square/sqldelight#compiled-statements)
+     */
+    @Deprecated
     public Marshal marshal(UserModel copy) {
       return new Marshal(copy, genderAdapter);
     }


### PR DESCRIPTION
Closes #519

Also deprecates the marshal and the `SqlDelightStatement` functions on the factory for insert/update/deletes