### PR TITLE
Generate name fields for views

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/SqliteCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/SqliteCompiler.kt
@@ -51,6 +51,13 @@ class SqliteCompiler {
       }
 
       status.views.forEach { queryResults ->
+        val name = queryResults.name
+
+        typeSpec.addField(FieldSpec.builder(String::class.java, "${name.toUpperCase()}_VIEW_NAME")
+            .addModifiers(PUBLIC, STATIC, FINAL)
+            .initializer("\$S", name)
+            .build())
+
         typeSpec.addType(queryResults.generateInterface())
         typeSpec.addType(queryResults.generateCreator())
       }

--- a/sqldelight-gradle-plugin/src/test/fixtures/duplicate-view-result-column-names/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/duplicate-view-result-column-names/expected/com/sample/TestModel.java
@@ -12,6 +12,8 @@ import java.lang.String;
 import java.util.Collections;
 
 public interface TestModel {
+  String VIEW1_VIEW_NAME = "view1";
+
   String TABLE_NAME = "test";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
@@ -15,6 +15,8 @@ import java.util.Collections;
 import java.util.List;
 
 public interface Test1Model {
+  String VIEW1_VIEW_NAME = "view1";
+
   String TABLE_NAME = "test";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
@@ -17,6 +17,16 @@ import java.util.LinkedHashSet;
 import java.util.List;
 
 public interface Test2Model {
+  String TEST2_COPY_VIEW_NAME = "test2_copy";
+
+  String MULTIPLE_TABLES_VIEW_NAME = "multiple_tables";
+
+  String SUB_VIEW_VIEW_NAME = "sub_view";
+
+  String PROJECTION_VIEW_VIEW_NAME = "projection_view";
+
+  String TEST2_PROJECTION_VIEW_NAME = "test2_projection";
+
   String TABLE_NAME = "test2";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/individual_table_columns/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/individual_table_columns/expected/com/sample/TestModel.java
@@ -12,6 +12,10 @@ import java.lang.String;
 import java.util.Collections;
 
 public interface TestModel {
+  String VIEW1_VIEW_NAME = "view1";
+
+  String VIEW2_VIEW_NAME = "view2";
+
   String TABLE_NAME = "test";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test2Model.java
@@ -13,6 +13,8 @@ import java.lang.String;
 import java.util.Collections;
 
 public interface Test2Model {
+  String VIEW1_VIEW_NAME = "view1";
+
   String TABLE_NAME = "test2";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/scoped-table-resolution/expected/com/test/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/scoped-table-resolution/expected/com/test/TestModel.java
@@ -13,6 +13,8 @@ import java.lang.String;
 import java.util.Collections;
 
 public interface TestModel {
+  String SOME_VIEW_VIEW_NAME = "some_view";
+
   String TABLE_NAME = "test";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestViewModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestViewModel.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.List;
 
 public interface TestViewModel {
+  String TEST_VIEW_VIEW_NAME = "test_view";
+
   String CREATE_VIEW = ""
       + "CREATE VIEW test_view AS SELECT id, date FROM test";
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test2Model.java
@@ -17,6 +17,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 
 public interface Test2Model {
+  String SOME_VIEW_VIEW_NAME = "some_view";
+
   String TABLE_NAME = "test2";
 
   String _ID = "_id";

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-file-no-args/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-file-no-args/expected/com/sample/TestModel.java
@@ -9,6 +9,8 @@ import java.lang.String;
 import java.util.Collections;
 
 public interface TestModel {
+  String TESTVIEW_VIEW_NAME = "testView";
+
   String CREATE_VIEW = ""
       + "CREATE VIEW testView AS SELECT * FROM settings";
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-preserves-type/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-preserves-type/expected/com/sample/TestModel.java
@@ -12,6 +12,8 @@ import java.lang.String;
 import java.util.Collections;
 
 public interface TestModel {
+  String VIEW1_VIEW_NAME = "view1";
+
   String TABLE_NAME = "test";
 
   String A_BOOLEAN = "a_boolean";


### PR DESCRIPTION
This should implement #354. I hope I did it right, please let me know whether something needs changing.

As a side note, I’ve been thinking that generating a field with an immutable list of table names each view consists of would be useful with SQLBrite since it could be used directly as a list of triggers for [`BriteDatabase#createQuery(Iterable<String>, String, String...)`][0].

I’d be happy to implement the above if it sounds reasonable.

[0]: https://square.github.io/sqlbrite/0.x/sqlbrite/com/squareup/sqlbrite/BriteDatabase.html#createQuery-java.lang.Iterable-java.lang.String-java.lang.String...-