### PR TITLE
Replaced mavenCentral with jcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ For the Gradle plugin:
 ```groovy
 buildscript {
   repositories {
-    mavenCentral()
+    jcenter()
   }
   dependencies {
     classpath 'com.squareup.sqldelight:gradle-plugin:0.5.1'


### PR DESCRIPTION
Better to have jcenter in the installation instructions as that is a superset of maven central.
Otherwise a lot of developers could end up with both `mavenCentral()` and `jcenter()` in their build.gradle files.