### PR TITLE
Improve test setup in the core module

### DIFF
--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/DuplicateSqlIdentifiers.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/DuplicateSqlIdentifiers.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.sqldelight.core
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.sqldelight.core.util.FixtureCompiler
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DuplicateSqlIdentifiers {
+
+  @JvmField @Rule val tempFolder = TemporaryFolder()
+
+  @Test fun duplicateQueryName() {
+    val result = FixtureCompiler.compileSql("""
+      |some_select:
+      |SELECT 1;
+      |
+      |some_select:
+      |SELECT 1;
+      |""".trimMargin(), tempFolder)
+
+    assertThat(result.errors).contains("Test.sq line 1:0 - Duplicate SQL identifier")
+    assertThat(result.errors).contains("Test.sq line 4:0 - Duplicate SQL identifier")
+  }
+}

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/DuplicateSqlIdentifiers.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/DuplicateSqlIdentifiers.kt
@@ -24,7 +24,7 @@ import org.junit.rules.TemporaryFolder
 
 class DuplicateSqlIdentifiers {
 
-  @JvmField @Rule val tempFolder = TemporaryFolder()
+  @get:Rule val tempFolder = TemporaryFolder()
 
   @Test fun duplicateQueryName() {
     val result = FixtureCompiler.compileSql("""

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/ErrorTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/ErrorTest.kt
@@ -1,64 +1,24 @@
 package com.squareup.sqldelight.core;
 
-import com.alecstrong.sqlite.psi.core.SqliteAnnotationHolder
 import com.google.common.truth.Truth.assertWithMessage
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.PsiElement
+import com.squareup.sqldelight.core.util.FixtureCompiler
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
 import java.io.File
-import java.util.ArrayList
 
-@RunWith(Parameterized::class)
-class ErrorTest(val fixtureRoot: File, val name: String) {
-  @Test fun execute() {
-    val parser = TestEnvironment()
-    val errors = ArrayList<String>()
+class ErrorTest {
 
-    val environment = parser.build(fixtureRoot.path, object : SqliteAnnotationHolder {
-      override fun createErrorAnnotation(element: PsiElement, s: String?) {
-        val documentManager = PsiDocumentManager.getInstance(element.project)
-        val name = element.containingFile.name
-        val document = documentManager.getDocument(element.containingFile)!!
-        val lineNum = document.getLineNumber(element.textOffset)
-        val offsetInLine = element.textOffset - document.getLineStartOffset(lineNum)
-        errors.add("$name line ${lineNum+1}:$offsetInLine - $s")
-      }
-    })
+  @Test fun duplicateSqliteIdentifiers() {
+    checkCompilationFails("duplicate-sqlite-identifiers")
+  }
 
-    val sourceFiles = StringBuilder()
-    environment.forSourceFiles {
-      sourceFiles.append("${it.name}:\n")
-      it.printTree {
-        sourceFiles.append("  ")
-        sourceFiles.append(it)
-      }
-    }
-
-    val expectedFailure = File(fixtureRoot, "failure.txt")
+  private fun checkCompilationFails(fixtureRoot: String) {
+    val result = FixtureCompiler.compileFixture("src/test/errors/$fixtureRoot")
+    val expectedFailure = File(result.fixtureRootDir, "failure.txt")
     if (expectedFailure.exists()) {
-      assertWithMessage(sourceFiles.toString()).that(errors).containsExactlyElementsIn(
-          expectedFailure.readText().split("\n").filterNot { it.isEmpty() }
-      )
+      assertWithMessage(result.sourceFiles).that(result.errors).containsExactlyElementsIn(
+          expectedFailure.readText().split("\n").filterNot { it.isEmpty() })
     } else {
-      assertWithMessage(sourceFiles.toString()).that(errors).isEmpty()
+      assertWithMessage(result.sourceFiles).that(result.errors).isEmpty()
     }
-  }
-
-  fun PsiElement.printTree(printer: (String) -> Unit) {
-    printer("$this\n")
-    children.forEach { child ->
-      child.printTree { printer("  $it") }
-    }
-  }
-
-  companion object {
-    @Suppress("unused") // Used by Parameterized JUnit runner reflectively.
-    @Parameters(name = "{1}")
-    @JvmStatic fun parameters() = File("src/test/errors").listFiles()
-        .filter { it.isDirectory }
-        .map { arrayOf(it, it.name) }
   }
 }

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
@@ -1,46 +1,28 @@
 package com.squareup.sqldelight.core.queries
 
-import com.google.common.truth.Truth
-import com.squareup.sqldelight.core.TestEnvironment
+import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler
-import com.squareup.sqldelight.core.lang.SqlDelightFile
+import com.squareup.sqldelight.core.util.FixtureCompiler
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
-import java.io.File
-import java.util.LinkedHashMap
 
-@RunWith(Parameterized::class)
-class InterfaceGeneration(val fixtureRoot: File, val name: String) {
-  @Test
-  fun execute() {
-    val parser = TestEnvironment()
-    val environment = parser.build(fixtureRoot.path)
-    val output = LinkedHashMap<String, StringBuilder>()
+class InterfaceGeneration {
 
-    environment.forSourceFiles { psiFile ->
-      SqlDelightCompiler.writeQueryInterfaces(psiFile as SqlDelightFile) { fileName ->
-        val builder = StringBuilder()
-        output.put(fileName, builder)
-        return@writeQueryInterfaces builder
-      }
-    }
-
-    for ((fileName, actualOutput) in output) {
-      val expectedFile = File(fixtureRoot, fileName)
-      Truth.assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
-
-      Truth.assertThat(expectedFile.readText()).named(fileName).isEqualTo(actualOutput.toString())
-    }
+  @Test fun noUniqueQueries() {
+    checkFixtureCompiles("no-unique-queries")
   }
 
-  companion object {
-    @Suppress("unused") // Used by Parameterized JUnit runner reflectively.
-    @Parameters(name = "{1}")
-    @JvmStatic fun parameters(): List<Array<Any>> =
-        File("src/test/query-interface-fixtures").listFiles()
-            .filter { it.isDirectory }
-            .map { arrayOf(it, it.name) }
+  @Test fun queryRequiresType() {
+    checkFixtureCompiles("query-requires-type")
+  }
+
+  private fun checkFixtureCompiles(fixtureRoot: String) {
+    val result = FixtureCompiler.compileFixture(
+        "src/test/query-interface-fixtures/$fixtureRoot",
+        SqlDelightCompiler::writeQueryInterfaces)
+    for ((expectedFile, actualOutput) in result.compilerOutput) {
+      assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
+      assertThat(expectedFile.readText()).named(expectedFile.name).isEqualTo(
+          actualOutput.toString())
+    }
   }
 }

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
@@ -1,45 +1,24 @@
 package com.squareup.sqldelight.core.tables
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.sqldelight.core.TestEnvironment
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler
-import com.squareup.sqldelight.core.lang.SqlDelightFile
+import com.squareup.sqldelight.core.util.FixtureCompiler
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
-import java.io.File
-import java.util.LinkedHashMap
 
-@RunWith(Parameterized::class)
-class InterfaceGeneration(val fixtureRoot: File, val name: String) {
-  @Test fun execute() {
-    val parser = TestEnvironment()
-    val environment = parser.build(fixtureRoot.path)
-    val output = LinkedHashMap<String, StringBuilder>()
+class InterfaceGeneration {
 
-    environment.forSourceFiles { psiFile ->
-      SqlDelightCompiler.writeTableInterfaces(psiFile as SqlDelightFile) { fileName ->
-        val builder = StringBuilder()
-        output.put(fileName, builder)
-        return@writeTableInterfaces builder
-      }
-    }
-
-    for ((fileName, actualOutput) in output) {
-      val expectedFile = File(fixtureRoot, fileName)
-      assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
-
-      assertThat(expectedFile.readText()).named(fileName).isEqualTo(actualOutput.toString())
-    }
+  @Test fun requiresAdapter() {
+    checkFixtureCompiles("requires-adapter")
   }
 
-  companion object {
-    @Suppress("unused") // Used by Parameterized JUnit runner reflectively.
-    @Parameters(name = "{1}")
-    @JvmStatic fun parameters(): List<Array<Any>> =
-        File("src/test/table-interface-fixtures").listFiles()
-            .filter { it.isDirectory }
-            .map { arrayOf(it, it.name) }
+  private fun checkFixtureCompiles(fixtureRoot: String) {
+    val result = FixtureCompiler.compileFixture(
+        "src/test/table-interface-fixtures/$fixtureRoot",
+        SqlDelightCompiler::writeTableInterfaces)
+    for ((expectedFile, actualOutput) in result.compilerOutput) {
+      assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
+      assertThat(expectedFile.readText()).named(expectedFile.name).isEqualTo(
+          actualOutput.toString())
+    }
   }
 }

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/util/FixtureCompiler.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/util/FixtureCompiler.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.sqldelight.core.util
+
+import com.alecstrong.sqlite.psi.core.SqliteAnnotationHolder
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.squareup.sqldelight.core.TestEnvironment
+import com.squareup.sqldelight.core.compiler.SqlDelightCompiler
+import com.squareup.sqldelight.core.lang.SqlDelightFile
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+private typealias CompilationMethod = (SqlDelightFile, (String) -> Appendable) -> Unit
+
+object FixtureCompiler {
+
+  fun compileSql(
+      sql: String,
+      temporaryFolder: TemporaryFolder,
+      compilationMethod: CompilationMethod = SqlDelightCompiler::compile
+  ): CompilationResult {
+    val srcRootDir = temporaryFolder.newFolder("src")
+    val fixtureRootDir = File(srcRootDir, "test/test-fixture").apply { mkdirs() }
+    val fixtureSrcDir = File(fixtureRootDir, "src/main/sqldelight").apply { mkdirs() }
+    File(fixtureSrcDir, "Test.sq").apply {
+      createNewFile()
+      writeText(sql)
+    }
+    return compileFixture(fixtureRootDir.path, compilationMethod)
+  }
+
+  fun compileFixture(
+      fixtureRoot: String,
+      compilationMethod: CompilationMethod = SqlDelightCompiler::compile
+  ): CompilationResult {
+    val compilerOutput = mutableMapOf<File, StringBuilder>()
+    val errors = mutableListOf<String>()
+    val sourceFiles = StringBuilder()
+    val parser = TestEnvironment()
+    val fixtureRootDir = File(fixtureRoot)
+    val environment = parser.build(fixtureRootDir.path, createAnnotationHolder(errors))
+    environment.forSourceFiles { psiFile ->
+      psiFile.log(sourceFiles)
+      compilationMethod(psiFile as SqlDelightFile) { fileName ->
+        val builder = StringBuilder()
+        compilerOutput += File(fixtureRootDir, fileName) to builder
+        return@compilationMethod builder
+      }
+    }
+    return CompilationResult(fixtureRootDir, compilerOutput, errors, sourceFiles.toString())
+  }
+
+  private fun createAnnotationHolder(
+      errors: MutableList<String>
+  ) = object : SqliteAnnotationHolder {
+    override fun createErrorAnnotation(element: PsiElement, s: String?) {
+      val documentManager = PsiDocumentManager.getInstance(element.project)
+      val name = element.containingFile.name
+      val document = documentManager.getDocument(element.containingFile)!!
+      val lineNum = document.getLineNumber(element.textOffset)
+      val offsetInLine = element.textOffset - document.getLineStartOffset(lineNum)
+      errors += "$name line ${lineNum + 1}:$offsetInLine - $s"
+    }
+  }
+
+  private fun PsiFile.log(sourceFiles: StringBuilder) {
+    sourceFiles.append("$name:\n")
+    printTree {
+      sourceFiles.append("  ")
+      sourceFiles.append(this)
+    }
+  }
+
+  private fun PsiElement.printTree(printer: (String) -> Unit) {
+    printer("$this\n")
+    children.forEach { child ->
+      child.printTree { printer("  $it") }
+    }
+  }
+
+  data class CompilationResult(
+      val fixtureRootDir: File,
+      val compilerOutput: Map<File, StringBuilder>,
+      val errors: List<String>,
+      val sourceFiles: String
+  )
+}

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
@@ -1,47 +1,28 @@
 package com.squareup.sqldelight.core.views
 
-import com.google.common.truth.Truth
-import com.squareup.sqldelight.core.TestEnvironment
+import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler
-import com.squareup.sqldelight.core.lang.SqlDelightFile
-import org.junit.Ignore
+import com.squareup.sqldelight.core.util.FixtureCompiler
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
-import java.io.File
-import java.util.LinkedHashMap
 
-@RunWith(Parameterized::class)
-class InterfaceGeneration(val fixtureRoot: File, val name: String) {
-  @Test
-  fun execute() {
-    val parser = TestEnvironment()
-    val environment = parser.build(fixtureRoot.path)
-    val output = LinkedHashMap<String, StringBuilder>()
+class InterfaceGeneration {
 
-    environment.forSourceFiles { psiFile ->
-      SqlDelightCompiler.writeViewInterfaces(psiFile as SqlDelightFile) { fileName ->
-        val builder = StringBuilder()
-        output.put(fileName, builder)
-        return@writeViewInterfaces builder
-      }
-    }
-
-    for ((fileName, actualOutput) in output) {
-      val expectedFile = File(fixtureRoot, fileName)
-      Truth.assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
-
-      Truth.assertThat(expectedFile.readText()).named(fileName).isEqualTo(actualOutput.toString())
-    }
+  @Test fun onlyTableType() {
+    checkFixtureCompiles("only-table-type")
   }
 
-  companion object {
-    @Suppress("unused") // Used by Parameterized JUnit runner reflectively.
-    @Parameters(name = "{1}")
-    @JvmStatic fun parameters(): List<Array<Any>> =
-        File("src/test/view-interface-fixtures").listFiles()
-            .filter { it.isDirectory }
-            .map { arrayOf(it, it.name) }
+  @Test fun requiresAdapter() {
+    checkFixtureCompiles("requires-adapter")
+  }
+
+  private fun checkFixtureCompiles(fixtureRoot: String) {
+    val result = FixtureCompiler.compileFixture(
+        "src/test/view-interface-fixtures/$fixtureRoot",
+        SqlDelightCompiler::writeViewInterfaces)
+    for ((expectedFile, actualOutput) in result.compilerOutput) {
+      assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
+      assertThat(expectedFile.readText()).named(expectedFile.name).isEqualTo(
+          actualOutput.toString())
+    }
   }
 }


### PR DESCRIPTION
- Move all under-test compilation logic into `FixtureCompiler`
- Extend setup to enable dynamic fixture creation, which allows using SQL strings as test inputs