### PR TITLE
Make the generated kotlin interface unaffected by the java interface

### DIFF
--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -49,8 +49,8 @@ object SqlDelightCompiler {
           FileSpec.builder(file.packageName, createTable.tableName.name)
               .apply {
                 val generator = TableInterfaceGenerator(createTable)
-                addType(generator.interfaceSpec())
                 addType(generator.kotlinInterfaceSpec())
+                addType(generator.interfaceSpec())
               }
               .build()
               .writeTo(output("${file.generatedDir}/${createTable.tableName.name.capitalize()}.kt"))
@@ -82,8 +82,8 @@ object SqlDelightCompiler {
           FileSpec.builder(file.packageName, namedQuery.name)
               .apply {
                 val generator = QueryInterfaceGenerator(namedQuery)
-                addType(generator.interfaceSpec())
                 addType(generator.kotlinInterfaceSpec())
+                addType(generator.interfaceSpec())
               }
               .build()
               .writeTo(output("${file.generatedDir}/${namedQuery.name.capitalize()}.kt"))

--- a/sqldelight-core/src/test/query-interface-fixtures/query-requires-type/com/sample/JoinedWithUsing.kt
+++ b/sqldelight-core/src/test/query-interface-fixtures/query-requires-type/com/sample/JoinedWithUsing.kt
@@ -4,19 +4,21 @@ import kotlin.Boolean
 import kotlin.String
 
 interface JoinedWithUsing {
-  fun name(): String
-
-  fun is_cool(): Boolean
-
-  data class Impl(override val name: String, override val is_cool: Boolean) : JoinedWithUsingKt
-}
-
-interface JoinedWithUsingKt : JoinedWithUsing {
   val name: String
 
   val is_cool: Boolean
 
-  override fun name(): String = name
+  data class Impl(override val name: String, override val is_cool: Boolean) : JoinedWithUsing
+}
 
-  override fun is_cool(): Boolean = is_cool
+abstract class JoinedWithUsingModel : JoinedWithUsing {
+  final override val name: String
+    get() = name()
+
+  final override val is_cool: Boolean
+    get() = is_cool()
+
+  abstract fun name(): String
+
+  abstract fun is_cool(): Boolean
 }

--- a/sqldelight-core/src/test/table-interface-fixtures/requires-adapter/com/sample/Person.kt
+++ b/sqldelight-core/src/test/table-interface-fixtures/requires-adapter/com/sample/Person.kt
@@ -9,31 +9,6 @@ import kotlin.Long
 import kotlin.String
 
 interface Person {
-  fun _id(): Long
-
-  fun name(): String
-
-  fun last_name(): String?
-
-  fun is_cool(): Boolean
-
-  fun friends(): List<Person>?
-
-  fun shhh_its_secret(): @Redacted String
-
-  class Adapter(internal val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>)
-
-  data class Impl(
-      override val _id: Long,
-      override val name: String,
-      override val last_name: String?,
-      override val is_cool: Boolean,
-      override val friends: List<Person>?,
-      override val shhh_its_secret: @Redacted String
-  ) : PersonKt
-}
-
-interface PersonKt : Person {
   val _id: Long
 
   val name: String
@@ -46,15 +21,46 @@ interface PersonKt : Person {
 
   val shhh_its_secret: @Redacted String
 
-  override fun _id(): Long = _id
+  class Adapter(internal val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>)
 
-  override fun name(): String = name
+  data class Impl(
+      override val _id: Long,
+      override val name: String,
+      override val last_name: String?,
+      override val is_cool: Boolean,
+      override val friends: List<Person>?,
+      override val shhh_its_secret: @Redacted String
+  ) : Person
+}
 
-  override fun last_name(): String? = last_name
+abstract class PersonModel : Person {
+  final override val _id: Long
+    get() = _id()
 
-  override fun is_cool(): Boolean = is_cool
+  final override val name: String
+    get() = name()
 
-  override fun friends(): List<Person>? = friends
+  final override val last_name: String?
+    get() = last_name()
 
-  override fun shhh_its_secret(): @Redacted String = shhh_its_secret
+  final override val is_cool: Boolean
+    get() = is_cool()
+
+  final override val friends: List<Person>?
+    get() = friends()
+
+  final override val shhh_its_secret: @Redacted String
+    get() = shhh_its_secret()
+
+  abstract fun _id(): Long
+
+  abstract fun name(): String
+
+  abstract fun last_name(): String?
+
+  abstract fun is_cool(): Boolean
+
+  abstract fun friends(): List<Person>?
+
+  abstract fun shhh_its_secret(): @Redacted String
 }

--- a/sqldelight-core/src/test/view-interface-fixtures/requires-adapter/com/sample/PersonAndFriends.kt
+++ b/sqldelight-core/src/test/view-interface-fixtures/requires-adapter/com/sample/PersonAndFriends.kt
@@ -6,23 +6,6 @@ import kotlin.Float
 import kotlin.String
 
 interface PersonAndFriends {
-  fun full_name(): String
-
-  fun friends(): List<Person>?
-
-  fun shhh_its_secret(): @Redacted String
-
-  fun casted(): Float
-
-  data class Impl(
-      override val full_name: String,
-      override val friends: List<Person>?,
-      override val shhh_its_secret: @Redacted String,
-      override val casted: Float
-  ) : PersonAndFriendsKt
-}
-
-interface PersonAndFriendsKt : PersonAndFriends {
   val full_name: String
 
   val friends: List<Person>?
@@ -31,11 +14,32 @@ interface PersonAndFriendsKt : PersonAndFriends {
 
   val casted: Float
 
-  override fun full_name(): String = full_name
+  data class Impl(
+      override val full_name: String,
+      override val friends: List<Person>?,
+      override val shhh_its_secret: @Redacted String,
+      override val casted: Float
+  ) : PersonAndFriends
+}
 
-  override fun friends(): List<Person>? = friends
+abstract class PersonAndFriendsModel : PersonAndFriends {
+  final override val full_name: String
+    get() = full_name()
 
-  override fun shhh_its_secret(): @Redacted String = shhh_its_secret
+  final override val friends: List<Person>?
+    get() = friends()
 
-  override fun casted(): Float = casted
+  final override val shhh_its_secret: @Redacted String
+    get() = shhh_its_secret()
+
+  final override val casted: Float
+    get() = casted()
+
+  abstract fun full_name(): String
+
+  abstract fun friends(): List<Person>?
+
+  abstract fun shhh_its_secret(): @Redacted String
+
+  abstract fun casted(): Float
 }

--- a/sqldelight-core/src/test/view-interface-fixtures/requires-adapter/com/sample/PersonCool.kt
+++ b/sqldelight-core/src/test/view-interface-fixtures/requires-adapter/com/sample/PersonCool.kt
@@ -7,32 +7,6 @@ import kotlin.Long
 import kotlin.String
 
 interface PersonCool {
-  fun _id(): Long
-
-  fun name(): String
-
-  fun last_name(): String?
-
-  fun is_cool(): Boolean
-
-  fun friends(): List<Person>?
-
-  fun shhh_its_secret(): @Redacted String
-
-  fun how_cool(): String
-
-  data class Impl(
-      override val _id: Long,
-      override val name: String,
-      override val last_name: String?,
-      override val is_cool: Boolean,
-      override val friends: List<Person>?,
-      override val shhh_its_secret: @Redacted String,
-      override val how_cool: String
-  ) : PersonCoolKt
-}
-
-interface PersonCoolKt : PersonCool {
   val _id: Long
 
   val name: String
@@ -47,17 +21,50 @@ interface PersonCoolKt : PersonCool {
 
   val how_cool: String
 
-  override fun _id(): Long = _id
+  data class Impl(
+      override val _id: Long,
+      override val name: String,
+      override val last_name: String?,
+      override val is_cool: Boolean,
+      override val friends: List<Person>?,
+      override val shhh_its_secret: @Redacted String,
+      override val how_cool: String
+  ) : PersonCool
+}
 
-  override fun name(): String = name
+abstract class PersonCoolModel : PersonCool {
+  final override val _id: Long
+    get() = _id()
 
-  override fun last_name(): String? = last_name
+  final override val name: String
+    get() = name()
 
-  override fun is_cool(): Boolean = is_cool
+  final override val last_name: String?
+    get() = last_name()
 
-  override fun friends(): List<Person>? = friends
+  final override val is_cool: Boolean
+    get() = is_cool()
 
-  override fun shhh_its_secret(): @Redacted String = shhh_its_secret
+  final override val friends: List<Person>?
+    get() = friends()
 
-  override fun how_cool(): String = how_cool
+  final override val shhh_its_secret: @Redacted String
+    get() = shhh_its_secret()
+
+  final override val how_cool: String
+    get() = how_cool()
+
+  abstract fun _id(): Long
+
+  abstract fun name(): String
+
+  abstract fun last_name(): String?
+
+  abstract fun is_cool(): Boolean
+
+  abstract fun friends(): List<Person>?
+
+  abstract fun shhh_its_secret(): @Redacted String
+
+  abstract fun how_cool(): String
 }


### PR DESCRIPTION
The idea being that if/when we generate bytecode instead the api is the same, and if we dont generate bytecode then all that changes from the java side is it extends an abstract class (sucks but whevs).