### PR TITLE
Upgrade to Android Gradle Plugin 3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,27 +89,13 @@ make implementations of the model:
 ```java
 @AutoValue
 public abstract class HockeyPlayer implements HockeyPlayerModel {
-  public static final Factory<HockeyPlayer> FACTORY = new Factory<>(new Creator<HockeyPlayer>() {
-    @Override public HockeyPlayer create(long _id, long player_number, String name) {
-      return new AutoValue_HockeyPlayer(_id, player_number, name);
-    }
-  });
-
-  public static final RowMapper<HockeyPlayer> SELECT_ALL_MAPPER = FACTORY.selectAllMapper();
-}
-```
-
-If you are also using [Retrolambda](https://github.com/orfjackal/retrolambda/) the anonymous class
-can be replaced by a method reference:
-
-```java
-@AutoValue
-public abstract class HockeyPlayer implements HockeyPlayerModel {
   public static final Factory<HockeyPlayer> FACTORY = new Factory<>(AutoValue_HockeyPlayer::new);
 
   public static final RowMapper<HockeyPlayer> SELECT_ALL_MAPPER = FACTORY.selectAllMapper();
 }
 ```
+
+Note: This snippet assumes you are using Java 8 to compile.
 
 
 Consuming Code

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ ext {
   ideaVersion = '2016.1'
 
   dep = [
-    androidPlugin: 'com.android.tools.build:gradle:2.3.3',
+    androidPlugin: 'com.android.tools.build:gradle:3.0.1',
     supportAnnotations: 'com.android.support:support-annotations:27.0.2',
     antlr: "org.antlr:antlr4:$antlrVersion",
     antlrRuntime: "org.antlr:antlr4-runtime:$antlrVersion",
@@ -21,7 +21,6 @@ ext {
     bugsnag: 'com.bugsnag:bugsnag:2.0.0',
     intellij: "IC-$ideaVersion",
     jps: "JPS-$ideaVersion",
-    retrolambda: 'me.tatarka:gradle-retrolambda:3.3.1',
     okio: 'com.squareup.okio:okio:1.11.0',
   ]
 
@@ -32,11 +31,16 @@ subprojects {
   buildscript {
     repositories {
       mavenCentral()
+      google()
       jcenter()
     }
 
     dependencies {
       classpath dep.kotlinGradlePlugin
+      classpath dep.androidPlugin
+
+      // Released version used for the sample project.
+      classpath 'com.squareup.sqldelight:gradle-plugin:0.6.1'
     }
   }
   repositories {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -38,7 +38,6 @@ dependencies {
   testImplementation dep.truth
 
   fixtureClasspath dep.kotlinGradlePlugin
-  fixtureClasspath dep.retrolambda
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
@@ -42,10 +42,12 @@ class SqlDelightPlugin : Plugin<Project> {
   private fun <T : BaseVariant> configureAndroid(project: Project, variants: DomainObjectSet<T>) {
     val generateSqlDelight = project.task("generateSqlDelightInterface")
 
-    val compileDeps = project.configurations.getByName("compile").dependencies
+    val compileDeps = project.configurations.getByName("api").dependencies
     if (System.getProperty("sqldelight.skip.runtime") != "true") {
       compileDeps.add(project.dependencies.create("com.squareup.sqldelight:runtime:$VERSION"))
     }
+    // TODO This shouldn't be needed as it's already a transitive dependency of the runtime. I'm
+    // pretty sure it only exists for our fixture tests.
     compileDeps.add(
         project.dependencies.create("com.android.support:support-annotations:23.1.1"))
 

--- a/sqldelight-gradle-plugin/src/test/integration/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration/build.gradle
@@ -5,15 +5,11 @@
 //  dependencies {
 //    classpath 'com.android.tools.build:gradle:2.2.0'
 //    classpath 'com.squareup.sqldelight:gradle-plugin:0.4.4'
-//    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-//    classpath 'me.tatarka:gradle-retrolambda:3.3.0'
 //  }
 //}
 //
 //apply plugin: 'com.android.application'
 //apply plugin: 'com.squareup.sqldelight'
-//apply plugin: 'com.neenbedankt.android-apt'
-//apply plugin: 'me.tatarka.retrolambda'
 //
 //configurations.all {
 //  resolutionStrategy {
@@ -24,7 +20,6 @@
 plugins {
   id 'com.android.application'
   id 'com.squareup.sqldelight'
-  id 'me.tatarka.retrolambda'
 }
 
 repositories {

--- a/sqldelight-runtime/build.gradle
+++ b/sqldelight-runtime/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-  dependencies {
-    classpath dep.androidPlugin
-  }
-}
-
 apply plugin: 'com.android.library'
 
 android {
@@ -29,10 +23,10 @@ android {
 }
 
 dependencies {
-  compile dep.supportAnnotations
+  implementation dep.supportAnnotations
 
-  testCompile dep.junit
-  testCompile dep.okio
+  testImplementation dep.junit
+  testImplementation dep.okio
 }
 
 configurations {

--- a/sqldelight-sample/build.gradle
+++ b/sqldelight-sample/build.gradle
@@ -1,19 +1,12 @@
-buildscript {
-  dependencies {
-    classpath dep.androidPlugin
-    classpath 'com.squareup.sqldelight:gradle-plugin:0.6.1'
-  }
-}
-
 apply plugin: 'com.android.application'
 apply plugin: 'com.squareup.sqldelight'
 
 dependencies {
-  compile 'com.jakewharton:butterknife:8.8.1'
+  implementation 'com.jakewharton:butterknife:8.8.1'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 
   annotationProcessor 'com.google.auto.value:auto-value:1.5.2'
-  provided 'com.jakewharton.auto.value:auto-value-annotations:1.5'
+  compileOnly 'com.jakewharton.auto.value:auto-value-annotations:1.5'
 }
 
 android {
@@ -58,4 +51,3 @@ android {
     }
   }
 }
-


### PR DESCRIPTION
This also removes Retrolambda in tests and the usage. Since we require AGP 3.x for consumers, it's safe enough to recommend the use of desugar for Java 8 language features.