### PR TITLE
Add a simple set for tables into the runtime.

### DIFF
--- a/sqldelight-gradle-plugin/src/test/fixtures/and-has-lower-precedence-than-and/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/and-has-lower-precedence-than-and/expected/com/sample/TestModel.java
@@ -4,11 +4,11 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public interface TestModel {
@@ -75,7 +75,7 @@ public interface TestModel {
       query.append('?').append(currentIndex++);
       args.add(TestText);
       query.append(" ESCAPE '\\' COLLATE NOCASE");
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("TEST"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("TEST"));
     }
 
     public Mapper<T> tEST_QUERYMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/bind-object/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/bind-object/expected/com/sample/TestModel.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -18,7 +19,6 @@ import java.lang.Short;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public interface TestModel {
@@ -72,7 +72,7 @@ public interface TestModel {
       }
       query.append("\n"
               + "FROM test");
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("test"));
     }
 
     public Mapper<T> some_selectMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/case-expression-type/expected/com/test/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/case-expression-type/expected/com/test/TestModel.java
@@ -5,10 +5,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -60,7 +60,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT CASE _id WHEN 0 THEN some_text ELSE some_text + _id END AS indexed_text\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public RowMapper<String> some_selectMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/cast-as-text/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/cast-as-text/expected/com/sample/TestModel.java
@@ -4,9 +4,9 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -78,7 +78,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT _id, CAST (_id AS TEXT)\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public <R extends Select_stuffModel> Select_stuffMapper<R> select_stuffMapper(Select_stuffCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/column-casing/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/column-casing/expected/com/sample/TestModel.java
@@ -4,9 +4,9 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -102,7 +102,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT mySTUFF, myOtherStuff\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public <R extends Some_selectModel> Some_selectMapper<R> some_selectMapper(Some_selectCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/duplicate-result-column-name/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/duplicate-result-column-name/expected/com/sample/TestModel.java
@@ -4,9 +4,9 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -77,7 +77,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT one._id, two._id\n"
           + "FROM test one, test two",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public <R extends Some_selectModel> Some_selectMapper<R> some_selectMapper(Some_selectCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/duplicate-view-result-column-names/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/duplicate-view-result-column-names/expected/com/sample/TestModel.java
@@ -4,9 +4,9 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String VIEW1_VIEW_NAME = "view1";
@@ -84,7 +84,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM view1",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public <R extends View1Model> View1Mapper<R> some_selectMapper(View1Creator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/TestModel.java
@@ -8,14 +8,12 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 
 public interface TestModel {
@@ -142,7 +140,7 @@ public interface TestModel {
         query.append('?').append(currentIndex++);
         args.add((String) enum_valueAdapter.encode(enum_value));
       }
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("test"));
     }
 
     public SqlDelightStatement local_enum_int(@Nullable Test.TestEnum enum_value_int) {
@@ -155,7 +153,7 @@ public interface TestModel {
       } else {
         query.append(enum_value_intAdapter.encode(enum_value_int));
       }
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement enum_array(@Nullable Test.TestEnum[] enum_value) {
@@ -172,7 +170,7 @@ public interface TestModel {
         args.add(enum_valueAdapter.encode(enum_value[i]));
       }
       query.append(')');
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("test"));
     }
 
     public SqlDelightStatement foreign_enum(ForeignTableModel.Factory<? extends ForeignTableModel> foreignTableModelFactory,
@@ -190,7 +188,7 @@ public interface TestModel {
         query.append('?').append(currentIndex++);
         args.add((String) foreignTableModelFactory.test_enumAdapter.encode(test_enum));
       }
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test","foreign_table"))));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("test", "foreign_table"));
     }
 
     public SqlDelightStatement multiple_foreign_enums(ForeignTableModel.Factory<? extends ForeignTableModel> foreignTableModelFactory,
@@ -231,7 +229,7 @@ public interface TestModel {
         args.add((String) foreignTableModelFactory.test_enumAdapter.encode(test_enum___));
       }
       query.append(")");
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test","foreign_table"))));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("test", "foreign_table"));
     }
 
     public SqlDelightStatement named_arg(@Nullable Test.TestEnum stuff) {
@@ -256,7 +254,7 @@ public interface TestModel {
         query.append('?').append(arg1Index);
       }
       query.append(" || '2'");
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("test"));
     }
 
     public Mapper<T> local_enumMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/expression-like/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/expression-like/expected/com/sample/TestModel.java
@@ -5,11 +5,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public interface TestModel {
@@ -117,7 +117,7 @@ public interface TestModel {
       query.append(" || '%'\n"
               + ")\n"
               + "ORDER BY department");
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("employee"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("employee"));
     }
 
     public Mapper<T> some_selectMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/function-nullability/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/function-nullability/expected/com/sample/TestModel.java
@@ -5,9 +5,9 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -217,7 +217,7 @@ public interface TestModel {
           + "SELECT gender, group_concat(DISTINCT name)\n"
           + "FROM test\n"
           + "GROUP BY gender",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement middle_names_for_gender() {
@@ -225,28 +225,28 @@ public interface TestModel {
           + "SELECT gender, group_concat(DISTINCT middle_name)\n"
           + "FROM test\n"
           + "GROUP BY gender",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement upper_names() {
       return new SqlDelightStatement(""
           + "SELECT upper(name), upper(middle_name)\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement lower_names() {
       return new SqlDelightStatement(""
           + "SELECT lower(name), lower(middle_name)\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement nullif_names() {
       return new SqlDelightStatement(""
           + "SELECT _id, nullif(name, middle_name)\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public <R extends Names_for_genderModel> Names_for_genderMapper<R> names_for_genderMapper(Names_for_genderCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/function-type-tests/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/function-type-tests/expected/com/test/UserModel.java
@@ -5,10 +5,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface UserModel {
   String TABLE_NAME = "users";
@@ -310,7 +310,7 @@ public interface UserModel {
           + "  min(age) as min_age\n"
           + "FROM users\n"
           + "GROUP BY gender",
-          new String[0], Collections.<String>singleton("users"));
+          new String[0], new TableSet("users"));
     }
 
     public <R extends SelectWithFunctionsModel> SelectWithFunctionsMapper<R> selectWithFunctionsMapper(SelectWithFunctionsCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
@@ -6,10 +6,10 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 public interface Test1Model {
@@ -189,7 +189,7 @@ public interface Test1Model {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM view1",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement other_select() {
@@ -197,7 +197,7 @@ public interface Test1Model {
           + "SELECT *\n"
           + "FROM view1\n"
           + "JOIN test USING (_id)",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement same_view() {
@@ -205,7 +205,7 @@ public interface Test1Model {
           + "SELECT *\n"
           + "FROM view1 first_view\n"
           + "JOIN view1 second_view",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public <R extends View1Model> View1Mapper<R> some_selectMapper(View1Creator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
@@ -6,12 +6,10 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 
 public interface Test2Model {
@@ -460,21 +458,21 @@ public interface Test2Model {
           + "SELECT *\n"
           + "FROM test2\n"
           + "JOIN view1 USING (_id)",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test2","test"))));
+          new String[0], new TableSet("test2", "test"));
     }
 
     public SqlDelightStatement view_select() {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM view1",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement copy_view_select() {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM test2_copy",
-          new String[0], Collections.<String>singleton("test2"));
+          new String[0], new TableSet("test2"));
     }
 
     public SqlDelightStatement multiple_view_select() {
@@ -482,7 +480,7 @@ public interface Test2Model {
           + "SELECT *\n"
           + "FROM test2_copy\n"
           + "JOIN multiple_tables",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test2","test"))));
+          new String[0], new TableSet("test2", "test"));
     }
 
     public SqlDelightStatement views_and_columns_select() {
@@ -490,7 +488,7 @@ public interface Test2Model {
           + "SELECT first_view.*, 'sup', second_view.*\n"
           + "FROM view1 first_view\n"
           + "JOIN view1 second_view",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement select_from_sub_view() {
@@ -498,21 +496,21 @@ public interface Test2Model {
           + "SELECT *, 'supsupsup'\n"
           + "FROM sub_view\n"
           + "JOIN test2_copy",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test","test2"))));
+          new String[0], new TableSet("test", "test2"));
     }
 
     public SqlDelightStatement select_from_projection() {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM projection_view",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement select_from_test2_projection() {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM test2_projection",
-          new String[0], Collections.<String>singleton("test2"));
+          new String[0], new TableSet("test2"));
     }
 
     public <V2 extends Test1Model.View1Model, R extends Other_selectModel<T, V2>> Other_selectMapper<T, V2, R> other_selectMapper(Other_selectCreator<T, V2, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/in-custom-foreign-type/expected/com/sample/TableOneModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/in-custom-foreign-type/expected/com/sample/TableOneModel.java
@@ -5,13 +5,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 
 public interface TableOneModel {
@@ -107,7 +105,7 @@ public interface TableOneModel {
         args.add(tableTwoModelFactory.typeAdapter.encode(types[i]));
       }
       query.append(')');
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("table_one","table_two"))));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("table_one", "table_two"));
     }
 
     public <T2 extends TableTwoModel, R extends Select_with_typesModel<T, T2>> Select_with_typesMapper<T, T2, R> select_with_typesMapper(Select_with_typesCreator<T, T2, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/individual_table_columns/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/individual_table_columns/expected/com/sample/TestModel.java
@@ -5,9 +5,9 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String VIEW1_VIEW_NAME = "view1";
@@ -215,42 +215,42 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement table_columns_select() {
       return new SqlDelightStatement(""
           + "SELECT _id, column1\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement view_select() {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM view1",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement view_columns_select() {
       return new SqlDelightStatement(""
           + "SELECT _id, column1\n"
           + "FROM view1",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement column_view_select() {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM view2",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement column_view_column_select() {
       return new SqlDelightStatement(""
           + "SELECT _id, column1\n"
           + "FROM view2",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public Mapper<T> table_selectMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/inner_view_query_using_join/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/inner_view_query_using_join/expected/com/sample/TestModel.java
@@ -5,11 +5,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
-import java.util.Collections;
 
 public interface TestModel {
   String SOME_VIEW_VIEW_NAME = "some_view";
@@ -93,7 +93,7 @@ public interface TestModel {
         query.append(row_id);
       }
       query.append(")");
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>singleton("settings"));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("settings"));
     }
 
     public <R extends Some_viewModel> Some_viewMapper<R> some_selectMapper(Some_viewCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/javadoc/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/javadoc/expected/com/sample/TestModel.java
@@ -5,11 +5,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -80,7 +80,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     /**
@@ -90,7 +90,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     /**
@@ -100,7 +100,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     /**
@@ -119,7 +119,7 @@ public interface TestModel {
         query.append('?').append(currentIndex++);
         args.add(name);
       }
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("test"));
     }
 
     /**

--- a/sqldelight-gradle-plugin/src/test/fixtures/keyword_identifiers/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/keyword_identifiers/expected/com/sample/TestModel.java
@@ -8,10 +8,10 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightCompiledStatement;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Boolean;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 public interface TestModel {
@@ -118,14 +118,14 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement get_desc() {
       return new SqlDelightStatement(""
           + "SELECT \"DESC\", [Boolean]\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public Mapper<T> some_selectMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableAModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableAModel.java
@@ -5,14 +5,12 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Integer;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 
 public interface TableAModel {
   String TABLE_NAME = "tablea";
@@ -132,7 +130,7 @@ public interface TableAModel {
       } else {
         query.append(col2);
       }
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("tablea","tableb"))));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("tablea", "tableb"));
     }
 
     public <T2 extends TableBModel, R extends Select_customModel<T, T2>> Select_customMapper<T, T2, R> select_customMapper(Select_customCreator<T, T2, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/sample/Test1Model.java
@@ -6,14 +6,12 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import com.test.Test2Model;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
-import java.util.LinkedHashSet;
 
 public interface Test1Model {
   String TABLE_NAME = "test1";
@@ -110,7 +108,7 @@ public interface Test1Model {
           + "SELECT *\n"
           + "FROM test1\n"
           + "JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test1","test2"))));
+          new String[0], new TableSet("test1", "test2"));
     }
 
     public <T2 extends Test2Model, R extends Join_tablesModel<T, T2>> Join_tablesMapper<T, T2, R> join_tablesMapper(Join_tablesCreator<T, T2, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/test/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/test/Test2Model.java
@@ -6,12 +6,10 @@ import android.support.annotation.Nullable;
 import com.sample.Test1Model;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 
 public interface Test2Model {
   String TABLE_NAME = "test2";
@@ -98,7 +96,7 @@ public interface Test2Model {
           + "SELECT *\n"
           + "FROM test2\n"
           + "JOIN test1",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test2","test1"))));
+          new String[0], new TableSet("test2", "test1"));
     }
 
     public <T2 extends Test1Model, R extends Join_tablesModel<T, T2>> Join_tablesMapper<T, T2, R> join_tablesMapper(Join_tablesCreator<T, T2, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/thing/Test3Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/thing/Test3Model.java
@@ -6,14 +6,11 @@ import android.support.annotation.Nullable;
 import com.sample.Test1Model;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import com.test.Test2Model;
 import java.lang.Long;
 import java.lang.Override;
-import java.lang.String;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
-import java.util.LinkedHashSet;
 
 public interface Test3Model {
   interface Join_tablesModel<T1 extends Test1Model, T2 extends Test2Model> {
@@ -255,14 +252,14 @@ public interface Test3Model {
           + "SELECT *\n"
           + "FROM test1\n"
           + "JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test1","test2"))));
+          new String[0], new TableSet("test1", "test2"));
     }
 
     public SqlDelightStatement one_table() {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM test1",
-          new String[0], Collections.<String>singleton("test1"));
+          new String[0], new TableSet("test1"));
     }
 
     public SqlDelightStatement tables_and_value() {
@@ -270,7 +267,7 @@ public interface Test3Model {
           + "SELECT test1.*, count(*), table_alias.*\n"
           + "FROM test2 AS table_alias\n"
           + "JOIN test1",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test2","test1"))));
+          new String[0], new TableSet("test2", "test1"));
     }
 
     public SqlDelightStatement custom_value() {
@@ -278,7 +275,7 @@ public interface Test3Model {
           + "SELECT test2.*, test1.*, test1.date\n"
           + "FROM test1\n"
           + "JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test1","test2"))));
+          new String[0], new TableSet("test1", "test2"));
     }
 
     public SqlDelightStatement aliased_custom_value() {
@@ -286,7 +283,7 @@ public interface Test3Model {
           + "SELECT test2.*, test1.*, test1.date AS created_date\n"
           + "FROM test1\n"
           + "JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test1","test2"))));
+          new String[0], new TableSet("test1", "test2"));
     }
 
     public SqlDelightStatement aliased_tables() {
@@ -295,14 +292,14 @@ public interface Test3Model {
           + "FROM test1 AS sender\n"
           + "JOIN test1 AS recipient\n"
           + "JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test1","test2"))));
+          new String[0], new TableSet("test1", "test2"));
     }
 
     public SqlDelightStatement single_value() {
       return new SqlDelightStatement(""
           + "SELECT count(_id)\n"
           + "FROM test1",
-          new String[0], Collections.<String>singleton("test1"));
+          new String[0], new TableSet("test1"));
     }
 
     public <R extends Join_tablesModel<T1, T2>> Join_tablesMapper<T1, T2, R> join_tablesMapper(Join_tablesCreator<T1, T2, R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test1Model.java
@@ -5,12 +5,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 
 public interface Test1Model {
   String TABLE_NAME = "test";
@@ -250,7 +248,7 @@ public interface Test1Model {
           + "SELECT *\n"
           + "FROM test\n"
           + "JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test","test2"))));
+          new String[0], new TableSet("test", "test2"));
     }
 
     public SqlDelightStatement left_join_table() {
@@ -258,7 +256,7 @@ public interface Test1Model {
           + "SELECT *\n"
           + "FROM test\n"
           + "LEFT JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test","test2"))));
+          new String[0], new TableSet("test", "test2"));
     }
 
     public SqlDelightStatement join_table_columns() {
@@ -266,7 +264,7 @@ public interface Test1Model {
           + "SELECT test.*, test2._id, nullable_int, nonnull_int\n"
           + "FROM test\n"
           + "JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test","test2"))));
+          new String[0], new TableSet("test", "test2"));
     }
 
     public SqlDelightStatement left_join_table_columns() {
@@ -274,7 +272,7 @@ public interface Test1Model {
           + "SELECT test.*, test2._id, nullable_int, nonnull_int\n"
           + "FROM test\n"
           + "LEFT JOIN test2",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test","test2"))));
+          new String[0], new TableSet("test", "test2"));
     }
 
     public <T2 extends Test2Model, R extends Join_tableModel<T, T2>> Join_tableMapper<T, T2, R> join_tableMapper(Join_tableCreator<T, T2, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test2Model.java
@@ -5,10 +5,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface Test2Model {
   String VIEW1_VIEW_NAME = "view1";
@@ -262,7 +262,7 @@ public interface Test2Model {
           + "SELECT *\n"
           + "FROM test2\n"
           + "JOIN view1",
-          new String[0], Collections.<String>singleton("test2"));
+          new String[0], new TableSet("test2"));
     }
 
     public SqlDelightStatement join_view_columns() {
@@ -270,7 +270,7 @@ public interface Test2Model {
           + "SELECT test2.*, view1.nullable_int, view1.nonnull_int\n"
           + "FROM test2\n"
           + "JOIN view1",
-          new String[0], Collections.<String>singleton("test2"));
+          new String[0], new TableSet("test2"));
     }
 
     public SqlDelightStatement left_join_view() {
@@ -278,7 +278,7 @@ public interface Test2Model {
           + "SELECT *\n"
           + "FROM test2\n"
           + "LEFT JOIN view1",
-          new String[0], Collections.<String>singleton("test2"));
+          new String[0], new TableSet("test2"));
     }
 
     public SqlDelightStatement left_join_view_columns() {
@@ -286,7 +286,7 @@ public interface Test2Model {
           + "SELECT test2.*, view1.nullable_int, view1.nonnull_int\n"
           + "FROM test2\n"
           + "LEFT JOIN view1",
-          new String[0], Collections.<String>singleton("test2"));
+          new String[0], new TableSet("test2"));
     }
 
     public <V2 extends View1Model, R extends Join_viewModel<T, V2>> Join_viewMapper<T, V2, R> join_viewMapper(Join_viewCreator<T, V2, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/scoped-table-resolution/expected/com/test/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/scoped-table-resolution/expected/com/test/TestModel.java
@@ -5,10 +5,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String SOME_VIEW_VIEW_NAME = "some_view";
@@ -73,7 +73,7 @@ public interface TestModel {
           + "SELECT *\n"
           + "FROM test\n"
           + "WHERE _id IN some_view",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public Mapper<T> some_selectMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestViewModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestViewModel.java
@@ -5,11 +5,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
-import java.util.Collections;
 import java.util.List;
 
 public interface TestViewModel {
@@ -61,7 +61,7 @@ public interface TestViewModel {
       StringBuilder query = new StringBuilder();
       query.append("SELECT * FROM test_view WHERE date > ");
       query.append(testModelFactory.dateAdapter.encode(date));
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement queryTest2(@Nullable Long id, @NonNull List date) {
@@ -74,7 +74,7 @@ public interface TestViewModel {
       }
       query.append(" AND date > ");
       query.append(testModelFactory.dateAdapter.encode(date));
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("test"));
     }
 
     public <R extends Test_viewModel> Test_viewMapper<R, T1> queryTest1Mapper(Test_viewCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/string-array-arg/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/string-array-arg/expected/com/sample/TestModel.java
@@ -6,11 +6,11 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public interface TestModel {
@@ -84,7 +84,7 @@ public interface TestModel {
         args.add(token[i]);
       }
       query.append(')');
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("test"));
     }
 
     public Mapper<T> some_queryMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/sum-uses-int/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/sum-uses-int/expected/com/sample/TestModel.java
@@ -4,11 +4,11 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Double;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "some_table";
@@ -64,21 +64,21 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT sum(quantity)\n"
           + "FROM some_table",
-          new String[0], Collections.<String>singleton("some_table"));
+          new String[0], new TableSet("some_table"));
     }
 
     public SqlDelightStatement get_rounded() {
       return new SqlDelightStatement(""
           + "SELECT round(some_real)\n"
           + "FROM some_table",
-          new String[0], Collections.<String>singleton("some_table"));
+          new String[0], new TableSet("some_table"));
     }
 
     public SqlDelightStatement get_rounded_arg() {
       return new SqlDelightStatement(""
           + "SELECT round(some_real, 1)\n"
           + "FROM some_table",
-          new String[0], Collections.<String>singleton("some_table"));
+          new String[0], new TableSet("some_table"));
     }
 
     public RowMapper<Long> get_sumMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test2Model.java
@@ -4,12 +4,10 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 
 public interface Test2Model {
   String SOME_VIEW_VIEW_NAME = "some_view";
@@ -87,7 +85,7 @@ public interface Test2Model {
               + "FROM some_view\n"
               + "WHERE _id=");
       query.append(_id);
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("test1","test2"))));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("test1", "test2"));
     }
 
     public <R extends Some_viewModel> Some_viewMapper<R> query_with_argMapper(Some_viewCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/union-adopts-type/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/union-adopts-type/expected/com/sample/TestModel.java
@@ -6,11 +6,11 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Calendar;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -268,7 +268,7 @@ public interface TestModel {
           + "UNION\n"
           + "SELECT nullable_text, null\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement union_type() {
@@ -278,7 +278,7 @@ public interface TestModel {
           + "UNION\n"
           + "SELECT nonnull_text, nonnull_text\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement union_tables_for_some_reason() {
@@ -287,7 +287,7 @@ public interface TestModel {
           + "FROM test\n"
           + "UNION\n"
           + "VALUES (1, null, null, null, null, null)",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement union_custom_types_keeps_type() {
@@ -297,7 +297,7 @@ public interface TestModel {
           + "UNION\n"
           + "SELECT custom_type, null\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement union_custom_type_uses_datatype() {
@@ -307,7 +307,7 @@ public interface TestModel {
           + "UNION\n"
           + "SELECT nullable_text, nonnull_int\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public <R extends Union_nullabilityModel> Union_nullabilityMapper<R> union_nullabilityMapper(Union_nullabilityCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/unnecessary-current-index/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/unnecessary-current-index/expected/com/sample/TestModel.java
@@ -4,10 +4,10 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -55,7 +55,7 @@ public interface TestModel {
       query.append(id);
       query.append("\n"
               + "LIMIT 1");
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("test"));
     }
 
     public Mapper<T> select_by_idMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-bind-array/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-bind-array/expected/com/sample/TestModel.java
@@ -4,10 +4,10 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
-import java.util.Collections;
 
 public interface TestModel {
   String TABLE_NAME = "test";
@@ -65,7 +65,7 @@ public interface TestModel {
         query.append(_id[i]);
       }
       query.append(')');
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>singleton("test"));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("test"));
     }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/fixtures/use-adapter-from-factory/expected/com/sample/BookModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/use-adapter-from-factory/expected/com/sample/BookModel.java
@@ -5,11 +5,11 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Calendar;
-import java.util.Collections;
 
 public interface BookModel {
   String TABLE_NAME = "book";
@@ -72,7 +72,7 @@ public interface BookModel {
           + "FROM book\n"
           + "ORDER BY published_at DESC\n"
           + "LIMIT 1",
-          new String[0], Collections.<String>singleton("book"));
+          new String[0], new TableSet("book"));
     }
 
     public SqlDelightStatement select_latest_title() {
@@ -81,7 +81,7 @@ public interface BookModel {
           + "FROM book\n"
           + "ORDER BY published_at DESC\n"
           + "LIMIT 1",
-          new String[0], Collections.<String>singleton("book"));
+          new String[0], new TableSet("book"));
     }
 
     public RowMapper<Calendar> select_latest_dateMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-file-no-args/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-file-no-args/expected/com/sample/TestModel.java
@@ -4,9 +4,9 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String TESTVIEW_VIEW_NAME = "testView";
@@ -55,13 +55,13 @@ public interface TestModel {
     public SqlDelightStatement load() {
       return new SqlDelightStatement(""
           + "SELECT * FROM testView",
-          new String[0], Collections.<String>singleton("settings"));
+          new String[0], new TableSet("settings"));
     }
 
     public SqlDelightStatement load2() {
       return new SqlDelightStatement(""
           + "SELECT * FROM testView WHERE row_id = 1",
-          new String[0], Collections.<String>singleton("settings"));
+          new String[0], new TableSet("settings"));
     }
 
     public <R extends TestViewModel<T1>> TestViewMapper<T1, R> loadMapper(TestViewCreator<T1, R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-in-view-requires-factory/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-in-view-requires-factory/expected/com/sample/TestModel.java
@@ -6,10 +6,10 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String SOME_VIEW_VIEW_NAME = "some_view";
@@ -120,7 +120,7 @@ public interface TestModel {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM some_view_2",
-          new String[0], Collections.<String>singleton("settings"));
+          new String[0], new TableSet("settings"));
     }
 
     public <V1 extends Some_viewModel, R extends Some_view_2Model<V1>> Some_view_2Mapper<V1, R, T> some_selectMapper(Some_view_2Creator<V1, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-preserves-type/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-preserves-type/expected/com/sample/TestModel.java
@@ -4,9 +4,9 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface TestModel {
   String VIEW1_VIEW_NAME = "view1";
@@ -117,14 +117,14 @@ public interface TestModel {
           + "UNION ALL\n"
           + "SELECT 0, a_boolean\n"
           + "FROM test",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public SqlDelightStatement select_from_view() {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM view1",
-          new String[0], Collections.<String>singleton("test"));
+          new String[0], new TableSet("test"));
     }
 
     public <R extends Some_selectModel> Some_selectMapper<R> some_selectMapper(Some_selectCreator<R> creator) {

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
@@ -6,16 +6,15 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 
 public interface HockeyPlayerModel {
@@ -425,7 +424,7 @@ public interface HockeyPlayerModel {
           + "SELECT *\n"
           + "FROM hockey_player\n"
           + "JOIN team ON hockey_player.team = team._id",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("hockey_player","team"))));
+          new String[0], new TableSet("hockey_player", "team"));
     }
 
     public SqlDelightStatement for_team(long _id) {
@@ -435,7 +434,7 @@ public interface HockeyPlayerModel {
               + "JOIN team ON hockey_player.team = team._id\n"
               + "WHERE team._id = ");
       query.append(_id);
-      return new SqlDelightStatement(query.toString(), new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("hockey_player","team"))));
+      return new SqlDelightStatement(query.toString(), new String[0], new TableSet("hockey_player", "team"));
     }
 
     public SqlDelightStatement join_friends() {
@@ -450,7 +449,7 @@ public interface HockeyPlayerModel {
           + "UNION SELECT hockey_player.*\n"
           + "FROM hockey_player\n"
           + "WHERE first_name = 'Matt'",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement subquery() {
@@ -460,7 +459,7 @@ public interface HockeyPlayerModel {
           + "  SELECT *\n"
           + "  FROM hockey_player\n"
           + ")",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement subquery_join() {
@@ -471,7 +470,7 @@ public interface HockeyPlayerModel {
           + "  FROM hockey_player AS stuff\n"
           + ")\n"
           + "JOIN hockey_player AS other_stuff",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement select_expression() {
@@ -479,7 +478,7 @@ public interface HockeyPlayerModel {
           + "SELECT first_name, count(*)\n"
           + "FROM hockey_player\n"
           + "GROUP BY first_name",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement expression_subquery() {
@@ -487,7 +486,7 @@ public interface HockeyPlayerModel {
           + "SELECT hockey_player.*, size\n"
           + "FROM hockey_player\n"
           + "JOIN (SELECT count(*) AS size FROM hockey_player)",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement order_by_age() {
@@ -495,7 +494,7 @@ public interface HockeyPlayerModel {
           + "SELECT *\n"
           + "FROM hockey_player\n"
           + "ORDER BY age",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement question_marks_everywhere(Object arg1, Object arg2, Object arg3,
@@ -540,7 +539,7 @@ public interface HockeyPlayerModel {
       query.append(" ASC\n"
               + "LIMIT ");
       query.append(arg6);
-      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), Collections.<String>singleton("hockey_player"));
+      return new SqlDelightStatement(query.toString(), args.toArray(new String[args.size()]), new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement subquery_uses_ignored_column() {
@@ -552,7 +551,7 @@ public interface HockeyPlayerModel {
           + "  WHERE age = 19\n"
           + ") as cheesy\n"
           + "WHERE cheesy.cheese = 10",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement kids() {
@@ -560,7 +559,7 @@ public interface HockeyPlayerModel {
           + "SELECT count(*)\n"
           + "FROM hockey_player\n"
           + "WHERE age=19",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement some_join() {
@@ -568,7 +567,7 @@ public interface HockeyPlayerModel {
           + "SELECT *\n"
           + "FROM hockey_player\n"
           + "INNER JOIN team ON hockey_player._id = team._id",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("hockey_player","team"))));
+          new String[0], new TableSet("hockey_player", "team"));
     }
 
     public SqlDelightStatement multiple_values_for_query() {
@@ -596,7 +595,7 @@ public interface HockeyPlayerModel {
           + "SELECT *\n"
           + "FROM hockey_player\n"
           + "WHERE _id IS NOT 2",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement order_by_expr() {
@@ -605,7 +604,7 @@ public interface HockeyPlayerModel {
           + "FROM hockey_player\n"
           + "ORDER BY age\n"
           + "LIMIT 1",
-          new String[0], Collections.<String>singleton("hockey_player"));
+          new String[0], new TableSet("hockey_player"));
     }
 
     public SqlDelightStatement inner_join() {
@@ -613,7 +612,7 @@ public interface HockeyPlayerModel {
           + "SELECT hockey_player.*\n"
           + "FROM hockey_player\n"
           + "INNER JOIN team ON hockey_player.team = team._id",
-          new String[0], Collections.<String>unmodifiableSet(new LinkedHashSet<String>(Arrays.asList("hockey_player","team"))));
+          new String[0], new TableSet("hockey_player", "team"));
     }
 
     public <T2 extends TeamModel, R extends Select_allModel<T, T2>> Select_allMapper<T, T2, R> select_allMapper(Select_allCreator<T, T2, R> creator,

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/TeamModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/TeamModel.java
@@ -6,11 +6,11 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Calendar;
-import java.util.Collections;
 
 public interface TeamModel {
   String TABLE_NAME = "team";
@@ -93,7 +93,7 @@ public interface TeamModel {
       return new SqlDelightStatement(""
           + "SELECT *\n"
           + "FROM team",
-          new String[0], Collections.<String>singleton("team"));
+          new String[0], new TableSet("team"));
     }
 
     public Mapper<T> select_allMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/expected/com/test/UserModel.java
@@ -6,9 +6,9 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface UserModel {
   String TABLE_NAME = "users";
@@ -91,7 +91,7 @@ public interface UserModel {
           + "SELECT *\n"
           + "FROM users\n"
           + "WHERE gender = 'FEMALE'",
-          new String[0], Collections.<String>singleton("users"));
+          new String[0], new TableSet("users"));
     }
 
     public Mapper<T> femalesMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine/expected/com/test/UserModel.java
@@ -6,11 +6,11 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Float;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -154,7 +154,7 @@ public interface UserModel {
           + "SELECT *\n"
           + "FROM users\n"
           + "WHERE gender = 'FEMALE'",
-          new String[0], Collections.<String>singleton("users"));
+          new String[0], new TableSet("users"));
     }
 
     public Mapper<T> femalesMapper() {

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-for-kotlin/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-for-kotlin/expected/com/test/UserModel.java
@@ -6,9 +6,9 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 
 public interface UserModel {
   String TABLE_NAME = "users";
@@ -91,7 +91,7 @@ public interface UserModel {
           + "SELECT *\n"
           + "FROM users\n"
           + "WHERE gender = 'FEMALE'",
-          new String[0], Collections.<String>singleton("users"));
+          new String[0], new TableSet("users"));
     }
 
     public Mapper<T> femalesMapper() {

--- a/sqldelight-runtime/src/main/java/com/squareup/sqldelight/internal/TableSet.java
+++ b/sqldelight-runtime/src/main/java/com/squareup/sqldelight/internal/TableSet.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqldelight.internal;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+
+/** A simple set of tables optimized for calls to {@link #contains} and {@link #iterator} */
+public final class TableSet extends AbstractSet<String> {
+  private final String[] values;
+
+  public TableSet(String... values) {
+    this.values = values;
+  }
+
+  @Override public boolean contains(Object o) {
+    for (String value : values) {
+      if (value.equals(o)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override public Iterator<String> iterator() {
+    return new TableIterator(values);
+  }
+
+  @Override public int size() {
+    return values.length;
+  }
+
+  private static final class TableIterator implements Iterator<String> {
+    private final String[] values;
+    private int i;
+
+    TableIterator(String[] values) {
+      this.values = values;
+    }
+
+    @Override public boolean hasNext() {
+      return i < values.length;
+    }
+
+    @Override public String next() {
+      return values[i++];
+    }
+  }
+}


### PR DESCRIPTION
This is for usage in the generated code to simplify it, eliminate intermediate copying and wrappers, as well as attempt to bimorphize the set call sites in SQL Brite (empty + TableSet only, ideally).