### PR TITLE
Use a variable for all runtime transitive deps.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -63,3 +63,7 @@ ext.deps = [
     junit: "junit:junit:$versions.junit",
     truth: "com.google.truth:truth:$versions.truth",
 ]
+
+ext.runtimeTransitiveDeps = [
+    deps.support.annotations,
+]

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
@@ -46,10 +46,6 @@ class SqlDelightPlugin : Plugin<Project> {
     if (System.getProperty("sqldelight.skip.runtime") != "true") {
       compileDeps.add(project.dependencies.create("com.squareup.sqldelight:runtime:$VERSION"))
     }
-    // TODO This shouldn't be needed as it's already a transitive dependency of the runtime. I'm
-    // pretty sure it only exists for our fixture tests.
-    compileDeps.add(
-        project.dependencies.create("com.android.support:support-annotations:23.1.1"))
 
     variants.all {
       val taskName = "generate${it.name.capitalize()}SqlDelightInterface"

--- a/sqldelight-gradle-plugin/src/test/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/build.gradle
@@ -9,6 +9,10 @@ repositories {
   google()
 }
 
+dependencies {
+  api runtimeTransitiveDeps
+}
+
 android {
   compileSdkVersion versions.compileSdk
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/build.gradle
@@ -9,6 +9,10 @@ repositories {
   google()
 }
 
+dependencies {
+  api runtimeTransitiveDeps
+}
+
 android {
   compileSdkVersion versions.compileSdk
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-for-kotlin/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-for-kotlin/build.gradle
@@ -11,6 +11,10 @@ repositories {
   google()
 }
 
+dependencies {
+  api runtimeTransitiveDeps
+}
+
 android {
   compileSdkVersion versions.compileSdk
 

--- a/sqldelight-gradle-plugin/src/test/integration/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration/build.gradle
@@ -30,6 +30,9 @@ repositories {
 }
 
 dependencies {
+  api runtimeTransitiveDeps
+
+  // TODO why don't these work when specified as androidTestImplementation?
   compile deps.support.test.runner
   compile deps.truth
 

--- a/sqldelight-runtime/build.gradle
+++ b/sqldelight-runtime/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-  implementation deps.support.annotations
+  api runtimeTransitiveDeps
 
   testImplementation deps.junit
 }


### PR DESCRIPTION
This allows us to remove a hack from the Gradle plugin which added them manually for the purpose of tests. Each test build.gradle just adds the runtime transitive deps manually using the variable.