### PR TITLE
Deprecate table and column constants.

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/SqliteCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/SqliteCompiler.kt
@@ -54,6 +54,7 @@ class SqliteCompiler {
         val name = queryResults.name
 
         typeSpec.addField(FieldSpec.builder(String::class.java, "${name.toUpperCase()}_VIEW_NAME")
+            .addAnnotation(java.lang.Deprecated::class.java)
             .addModifiers(PUBLIC, STATIC, FINAL)
             .initializer("\$S", name)
             .build())
@@ -74,6 +75,7 @@ class SqliteCompiler {
         table = Table(parseContext.sql_stmt_list().create_table_stmt(), symbolTable)
 
         typeSpec.addField(FieldSpec.builder(String::class.java, TABLE_NAME)
+            .addAnnotation(java.lang.Deprecated::class.java)
             .addModifiers(PUBLIC, STATIC, FINAL)
             .initializer("\$S", table.name)
             .build())
@@ -88,6 +90,7 @@ class SqliteCompiler {
           }
 
           val columnConstantBuilder = FieldSpec.builder(String::class.java, column.constantName)
+              .addAnnotation(java.lang.Deprecated::class.java)
               .addModifiers(PUBLIC, STATIC, FINAL)
               .initializer("\$S", column.name.columnName())
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/and-has-lower-precedence-than-and/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/and-has-lower-precedence-than-and/expected/com/sample/TestModel.java
@@ -6,16 +6,21 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "TEST";
 
+  @Deprecated
   String TESTID = "TestId";
 
+  @Deprecated
   String TESTTEXT = "TestText";
 
+  @Deprecated
   String SECONDID = "SecondId";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/bind-object/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/bind-object/expected/com/sample/TestModel.java
@@ -10,6 +10,7 @@ import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.SqlDelightStatement;
 import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Float;
 import java.lang.IllegalArgumentException;
@@ -21,8 +22,10 @@ import java.lang.Short;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/case-expression-type/expected/com/test/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/case-expression-type/expected/com/test/TestModel.java
@@ -6,15 +6,19 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String SOME_TEXT = "some_text";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/cast-as-text/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/cast-as-text/expected/com/sample/TestModel.java
@@ -5,12 +5,15 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/column-annotations/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/column-annotations/expected/com/sample/TestModel.java
@@ -13,20 +13,28 @@ import java.lang.SuppressWarnings;
 import java.util.List;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String DEPRECATED = "deprecated";
 
+  @Deprecated
   String SUPPRESSED_WARNINGS = "suppressed_warnings";
 
+  @Deprecated
   String SUPPRESSED_WARNINGS_VALUE = "suppressed_warnings_value";
 
+  @Deprecated
   String CLASS_ANNOTATION = "class_annotation";
 
+  @Deprecated
   String INTEGER_ANNOTATION = "integer_annotation";
 
+  @Deprecated
   String STRING_ARRAY_ANNOTATION = "string_array_annotation";
 
+  @Deprecated
   String MULTIPLE_VALUES_ANNOTATION = "multiple_values_annotation";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/column-casing/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/column-casing/expected/com/sample/TestModel.java
@@ -5,18 +5,24 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String STUFF = "STUFF";
 
+  @Deprecated
   String MYSTUFF = "mySTUFF";
 
+  @Deprecated
   String LOWERCASE_STUFF = "lowercase_stuff";
 
+  @Deprecated
   String MYOTHERSTUFF = "myOtherStuff";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/create-trigger-duplicate-column/expected/com/sample/SimpleTableModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/create-trigger-duplicate-column/expected/com/sample/SimpleTableModel.java
@@ -3,14 +3,18 @@ package com.sample;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface SimpleTableModel {
+  @Deprecated
   String TABLE_NAME = "SimpleTable";
 
+  @Deprecated
   String ID = "id";
 
+  @Deprecated
   String TEXT = "text";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/expected/com/test/UserModel.java
@@ -5,14 +5,18 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface UserModel {
+  @Deprecated
   String TABLE_NAME = "user";
 
+  @Deprecated
   String BALANCE = "balance";
 
+  @Deprecated
   String BALANCE_NULLABLE = "balance_nullable";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/delete-compiled-statement/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/delete-compiled-statement/expected/com/sample/TestModel.java
@@ -6,12 +6,15 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String SOME_COLUMN = "some_column";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/duplicate-result-column-name/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/duplicate-result-column-name/expected/com/sample/TestModel.java
@@ -5,12 +5,15 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/duplicate-view-result-column-names/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/duplicate-view-result-column-names/expected/com/sample/TestModel.java
@@ -5,14 +5,18 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String VIEW1_VIEW_NAME = "view1";
 
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/ForeignTableModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/ForeignTableModel.java
@@ -7,14 +7,18 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface ForeignTableModel {
+  @Deprecated
   String TABLE_NAME = "foreign_table";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String TEST_ENUM = "test_enum";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/enum-bind-args/expected/com/sample/TestModel.java
@@ -11,19 +11,25 @@ import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.SqlDelightStatement;
 import com.squareup.sqldelight.internal.QuestionMarks;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String ENUM_VALUE = "enum_value";
 
+  @Deprecated
   String ENUM_VALUE_INT = "enum_value_int";
 
+  @Deprecated
   String FOREIGN_KEY = "foreign_key";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/expression-like/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/expression-like/expected/com/sample/TestModel.java
@@ -7,20 +7,27 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "employee";
 
+  @Deprecated
   String ID = "id";
 
+  @Deprecated
   String DEPARTMENT = "department";
 
+  @Deprecated
   String NAME = "name";
 
+  @Deprecated
   String TITLE = "title";
 
+  @Deprecated
   String BIO = "bio";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/expression-subquery/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/expression-subquery/expected/com/sample/Test2Model.java
@@ -3,14 +3,18 @@ package com.sample;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface Test2Model {
+  @Deprecated
   String TABLE_NAME = "test2";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String TESTID = "testId";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/expression-subquery/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/expression-subquery/expected/com/sample/TestModel.java
@@ -6,14 +6,18 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String SOMESTRING = "someString";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/function-nullability/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/function-nullability/expected/com/sample/TestModel.java
@@ -6,18 +6,24 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String NAME = "name";
 
+  @Deprecated
   String GENDER = "gender";
 
+  @Deprecated
   String MIDDLE_NAME = "middle_name";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/function-type-tests/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/function-type-tests/expected/com/test/UserModel.java
@@ -6,17 +6,22 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface UserModel {
+  @Deprecated
   String TABLE_NAME = "users";
 
+  @Deprecated
   String ID = "id";
 
+  @Deprecated
   String AGE = "age";
 
+  @Deprecated
   String GENDER = "gender";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test1Model.java
@@ -7,20 +7,26 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 
 public interface Test1Model {
+  @Deprecated
   String VIEW1_VIEW_NAME = "view1";
 
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String COLUMN1 = "column1";
 
+  @Deprecated
   String COLUMN2 = "column2";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/generate-view-mappers/expected/com/sample/Test2Model.java
@@ -7,28 +7,38 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 
 public interface Test2Model {
+  @Deprecated
   String TEST2_COPY_VIEW_NAME = "test2_copy";
 
+  @Deprecated
   String MULTIPLE_TABLES_VIEW_NAME = "multiple_tables";
 
+  @Deprecated
   String SUB_VIEW_VIEW_NAME = "sub_view";
 
+  @Deprecated
   String PROJECTION_VIEW_VIEW_NAME = "projection_view";
 
+  @Deprecated
   String TEST2_PROJECTION_VIEW_NAME = "test2_projection";
 
+  @Deprecated
   String TABLE_NAME = "test2";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String COLUMN1 = "column1";
 
+  @Deprecated
   String COLUMN2 = "column2";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/in-custom-foreign-type/expected/com/sample/TableOneModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/in-custom-foreign-type/expected/com/sample/TableOneModel.java
@@ -8,13 +8,16 @@ import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.QuestionMarks;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 
 public interface TableOneModel {
+  @Deprecated
   String TABLE_NAME = "table_one";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/in-custom-foreign-type/expected/com/sample/TableTwoModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/in-custom-foreign-type/expected/com/sample/TableTwoModel.java
@@ -5,15 +5,19 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 
 public interface TableTwoModel {
+  @Deprecated
   String TABLE_NAME = "table_two";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String TYPE = "type";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/individual_table_columns/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/individual_table_columns/expected/com/sample/TestModel.java
@@ -6,18 +6,24 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String VIEW1_VIEW_NAME = "view1";
 
+  @Deprecated
   String VIEW2_VIEW_NAME = "view2";
 
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String COLUMN1 = "column1";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/inner_view_query_using_join/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/inner_view_query_using_join/expected/com/sample/TestModel.java
@@ -7,15 +7,19 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String SOME_VIEW_VIEW_NAME = "some_view";
 
+  @Deprecated
   String TABLE_NAME = "settings";
 
+  @Deprecated
   String ROW_ID = "row_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/insert-default-values/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/insert-default-values/expected/com/sample/TestModel.java
@@ -5,14 +5,18 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String NAME = "name";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/javadoc/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/javadoc/expected/com/sample/TestModel.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
@@ -14,16 +15,19 @@ import java.lang.String;
  * This is a table.
  */
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
   /**
    * This is a column.
    */
+  @Deprecated
   String _ID = "_id";
 
   /**
    * Another
    */
+  @Deprecated
   String NAME = "name";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/keyword_identifiers/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/keyword_identifiers/expected/com/sample/TestModel.java
@@ -10,21 +10,28 @@ import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.SqlDelightStatement;
 import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String ASC = "ASC";
 
+  @Deprecated
   String DESC = "DESC";
 
+  @Deprecated
   String TEXT = "TEXT";
 
+  @Deprecated
   String BOOLEAN = "Boolean";
 
+  @Deprecated
   String NEW_ = "new";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableAModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableAModel.java
@@ -7,16 +7,20 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Integer;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TableAModel {
+  @Deprecated
   String TABLE_NAME = "tablea";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String TABLEB_ID = "tableb_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableBModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/left-join-bind-args/expected/com/sample/TableBModel.java
@@ -4,17 +4,22 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TableBModel {
+  @Deprecated
   String TABLE_NAME = "tableb";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String COL1 = "col1";
 
+  @Deprecated
   String COL2 = "col2";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/sample/Test1Model.java
@@ -8,16 +8,20 @@ import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
 import com.test.Test2Model;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Date;
 
 public interface Test1Model {
+  @Deprecated
   String TABLE_NAME = "test1";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String DATE = "date";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/test/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/mapper-interfaces/expected/com/test/Test2Model.java
@@ -7,13 +7,16 @@ import com.sample.Test1Model;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface Test2Model {
+  @Deprecated
   String TABLE_NAME = "test2";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test1Model.java
@@ -6,17 +6,22 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface Test1Model {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String NULLABLE_TEXT = "nullable_text";
 
+  @Deprecated
   String NONNULL_TEXT = "nonnull_text";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullability/expected/com/sample/Test2Model.java
@@ -6,21 +6,28 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface Test2Model {
+  @Deprecated
   String VIEW1_VIEW_NAME = "view1";
 
+  @Deprecated
   String TABLE_NAME = "test2";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String NULLABLE_INT = "nullable_int";
 
+  @Deprecated
   String NONNULL_INT = "nonnull_int";
 
+  @Deprecated
   String TEST2_ID = "test2_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullable-boolean/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullable-boolean/expected/com/test/UserModel.java
@@ -5,12 +5,15 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface UserModel {
+  @Deprecated
   String TABLE_NAME = "users";
 
+  @Deprecated
   String TALL = "tall";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/nullable-enum/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/nullable-enum/expected/com/test/UserModel.java
@@ -5,12 +5,15 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface UserModel {
+  @Deprecated
   String TABLE_NAME = "users";
 
+  @Deprecated
   String GENDER = "gender";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/scoped-table-resolution/expected/com/test/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/scoped-table-resolution/expected/com/test/TestModel.java
@@ -6,15 +6,19 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String SOME_VIEW_VIEW_NAME = "some_view";
 
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestModel.java
@@ -5,16 +5,20 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String ID = "id";
 
+  @Deprecated
   String DATE = "date";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestViewModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/second-arg-requires-factory/expected/com/sample/TestViewModel.java
@@ -7,12 +7,14 @@ import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;
 
 public interface TestViewModel {
+  @Deprecated
   String TEST_VIEW_VIEW_NAME = "test_view";
 
   String CREATE_VIEW = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/sql-types-to-java-types/expected/com/test/TypeModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/sql-types-to-java-types/expected/com/test/TypeModel.java
@@ -9,6 +9,7 @@ import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Float;
 import java.lang.Integer;
@@ -18,86 +19,127 @@ import java.lang.Short;
 import java.lang.String;
 
 public interface TypeModel {
+  @Deprecated
   String TABLE_NAME = "types";
 
+  @Deprecated
   String I = "i";
 
+  @Deprecated
   String I_NOT_NULL = "i_not_null";
 
+  @Deprecated
   String I_AS_BOOL = "i_as_bool";
 
+  @Deprecated
   String I_AS_BOOL_NOT_NULL = "i_as_bool_not_null";
 
+  @Deprecated
   String I_AS_INT = "i_as_int";
 
+  @Deprecated
   String I_AS_INT_NOT_NULL = "i_as_int_not_null";
 
+  @Deprecated
   String I_AS_SHORT = "i_as_short";
 
+  @Deprecated
   String I_AS_SHORT_NOT_NULL = "i_as_short_not_null";
 
+  @Deprecated
   String I_AS_LONG = "i_as_long";
 
+  @Deprecated
   String I_AS_LONG_NOT_NULL = "i_as_long_not_null";
 
+  @Deprecated
   String I_AS_DOUBLE = "i_as_double";
 
+  @Deprecated
   String I_AS_DOUBLE_NOT_NULL = "i_as_double_not_null";
 
+  @Deprecated
   String I_AS_CUSTOM = "i_as_custom";
 
+  @Deprecated
   String I_AS_CUSTOM_NOT_NULL = "i_as_custom_not_null";
 
+  @Deprecated
   String R = "r";
 
+  @Deprecated
   String R_NOT_NULL = "r_not_null";
 
+  @Deprecated
   String R_AS_FLOAT = "r_as_float";
 
+  @Deprecated
   String R_AS_FLOAT_NOT_NULL = "r_as_float_not_null";
 
+  @Deprecated
   String R_AS_DOUBLE = "r_as_double";
 
+  @Deprecated
   String R_AS_DOUBLE_NOT_NULL = "r_as_double_not_null";
 
+  @Deprecated
   String R_AS_INT = "r_as_int";
 
+  @Deprecated
   String R_AS_INT_NOT_NULL = "r_as_int_not_null";
 
+  @Deprecated
   String R_AS_CUSTOM = "r_as_custom";
 
+  @Deprecated
   String R_AS_CUSTOM_NOT_NULL = "r_as_custom_not_null";
 
+  @Deprecated
   String T = "t";
 
+  @Deprecated
   String T_NOT_NULL = "t_not_null";
 
+  @Deprecated
   String T_AS_STRING = "t_as_string";
 
+  @Deprecated
   String T_AS_STRING_NOT_NULL = "t_as_string_not_null";
 
+  @Deprecated
   String T_AS_LONG = "t_as_long";
 
+  @Deprecated
   String T_AS_LONG_NOT_NULL = "t_as_long_not_null";
 
+  @Deprecated
   String T_AS_CUSTOM = "t_as_custom";
 
+  @Deprecated
   String T_AS_CUSTOM_NOT_NULL = "t_as_custom_not_null";
 
+  @Deprecated
   String B = "b";
 
+  @Deprecated
   String B_NOT_NULL = "b_not_null";
 
+  @Deprecated
   String B_AS_BYTES = "b_as_bytes";
 
+  @Deprecated
   String B_AS_BYTES_NOT_NULL = "b_as_bytes_not_null";
 
+  @Deprecated
   String B_AS_STRING = "b_as_string";
 
+  @Deprecated
   String B_AS_STRING_NOT_NULL = "b_as_string_not_null";
 
+  @Deprecated
   String B_AS_CUSTOM = "b_as_custom";
 
+  @Deprecated
   String B_AS_CUSTOM_NOT_NULL = "b_as_custom_not_null";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/sqlite-keyword-java-package/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/sqlite-keyword-java-package/expected/com/sample/TestModel.java
@@ -5,13 +5,16 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 import no.test.TestEnum;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test_table";
 
+  @Deprecated
   String TEST_COLUMN = "test_column";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/statement-bind-args/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/statement-bind-args/expected/com/sample/TestModel.java
@@ -8,18 +8,24 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String SOME_BOOL = "some_bool";
 
+  @Deprecated
   String SOME_ENUM = "some_enum";
 
+  @Deprecated
   String SOME_BLOB = "some_blob";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/string-array-arg/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/string-array-arg/expected/com/sample/TestModel.java
@@ -9,14 +9,18 @@ import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.QuestionMarks;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String TOKEN = "token";
 
+  @Deprecated
   String SOME_ENUM = "some_enum";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/FolderModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/FolderModel.java
@@ -3,14 +3,18 @@ package com.sample;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface FolderModel {
+  @Deprecated
   String TABLE_NAME = "folder";
 
+  @Deprecated
   String FID = "fid";
 
+  @Deprecated
   String TOTAL_COUNTER = "total_counter";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/MessageModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/subselect-in-delete/expected/com/sample/MessageModel.java
@@ -5,14 +5,18 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface MessageModel {
+  @Deprecated
   String TABLE_NAME = "message";
 
+  @Deprecated
   String MID = "mid";
 
+  @Deprecated
   String FID = "fid";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/sum-uses-int/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/sum-uses-int/expected/com/sample/TestModel.java
@@ -5,18 +5,23 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "some_table";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String QUANTITY = "quantity";
 
+  @Deprecated
   String SOME_REAL = "some_real";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test1Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test1Model.java
@@ -3,12 +3,15 @@ package com.sample;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface Test1Model {
+  @Deprecated
   String TABLE_NAME = "test1";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test2Model.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/tables-through-view/expected/com/sample/Test2Model.java
@@ -6,14 +6,18 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface Test2Model {
+  @Deprecated
   String SOME_VIEW_VIEW_NAME = "some_view";
 
+  @Deprecated
   String TABLE_NAME = "test2";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/trigger-raise/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/trigger-raise/expected/com/sample/TestModel.java
@@ -3,12 +3,15 @@ package com.sample;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/union-adopts-type/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/union-adopts-type/expected/com/sample/TestModel.java
@@ -7,24 +7,32 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Calendar;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String NULLABLE_TEXT = "nullable_text";
 
+  @Deprecated
   String NONNULL_TEXT = "nonnull_text";
 
+  @Deprecated
   String NULLABLE_INT = "nullable_int";
 
+  @Deprecated
   String NONNULL_INT = "nonnull_int";
 
+  @Deprecated
   String CUSTOM_TYPE = "custom_type";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/unnecessary-current-index/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/unnecessary-current-index/expected/com/sample/TestModel.java
@@ -6,12 +6,15 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String ID = "id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-bind-args-order/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-bind-args-order/expected/com/sample/TestModel.java
@@ -5,16 +5,21 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "foo";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String BAR = "bar";
 
+  @Deprecated
   String BAZ = "baz";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-bind-array/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-bind-array/expected/com/sample/TestModel.java
@@ -7,14 +7,18 @@ import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.QuestionMarks;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String SOME_TEXT = "some_text";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-expression-has-columns/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-expression-has-columns/expected/com/sample/TestModel.java
@@ -6,15 +6,19 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String ID_LESS_THAN_FOUR = "id_less_than_four";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-inner-select/expected/com/sample/FolderModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-inner-select/expected/com/sample/FolderModel.java
@@ -5,14 +5,18 @@ import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface FolderModel {
+  @Deprecated
   String TABLE_NAME = "folder";
 
+  @Deprecated
   String FID = "fid";
 
+  @Deprecated
   String TOTAL_COUNTER = "total_counter";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-inner-select/expected/com/sample/MessageModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-inner-select/expected/com/sample/MessageModel.java
@@ -3,14 +3,18 @@ package com.sample;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface MessageModel {
+  @Deprecated
   String TABLE_NAME = "message";
 
+  @Deprecated
   String MID = "mid";
 
+  @Deprecated
   String FID = "fid";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/update-where-bind/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/update-where-bind/expected/com/sample/TestModel.java
@@ -6,32 +6,45 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightStatement;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TABLE_NAME = "test_table";
 
+  @Deprecated
   String COLUMN1 = "column1";
 
+  @Deprecated
   String COLUMN2 = "column2";
 
+  @Deprecated
   String COLUMN3 = "column3";
 
+  @Deprecated
   String COLUMN4 = "column4";
 
+  @Deprecated
   String COLUMN5 = "column5";
 
+  @Deprecated
   String COLUMN6 = "column6";
 
+  @Deprecated
   String COLUMN7 = "column7";
 
+  @Deprecated
   String COLUMN8 = "column8";
 
+  @Deprecated
   String COLUMN9 = "column9";
 
+  @Deprecated
   String COLUMN10 = "column10";
 
+  @Deprecated
   String COLUMN11 = "column11";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/use-adapter-from-factory/expected/com/sample/BookModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/use-adapter-from-factory/expected/com/sample/BookModel.java
@@ -6,18 +6,23 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Calendar;
 
 public interface BookModel {
+  @Deprecated
   String TABLE_NAME = "book";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String TITLE = "title";
 
+  @Deprecated
   String PUBLISHED_AT = "published_at";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-file-no-args/expected/com/sample/SettingsModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-file-no-args/expected/com/sample/SettingsModel.java
@@ -3,12 +3,15 @@ package com.sample;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface SettingsModel {
+  @Deprecated
   String TABLE_NAME = "settings";
 
+  @Deprecated
   String ROW_ID = "row_id";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-file-no-args/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-file-no-args/expected/com/sample/TestModel.java
@@ -5,10 +5,12 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String TESTVIEW_VIEW_NAME = "testView";
 
   String CREATE_VIEW = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-in-view-requires-factory/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-in-view-requires-factory/expected/com/sample/TestModel.java
@@ -7,19 +7,25 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String SOME_VIEW_VIEW_NAME = "some_view";
 
+  @Deprecated
   String SOME_VIEW_2_VIEW_NAME = "some_view_2";
 
+  @Deprecated
   String TABLE_NAME = "settings";
 
+  @Deprecated
   String ROW_ID = "row_id";
 
+  @Deprecated
   String SOME_COLUMN = "some_column";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/view-preserves-type/expected/com/sample/TestModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/view-preserves-type/expected/com/sample/TestModel.java
@@ -5,14 +5,18 @@ import android.support.annotation.NonNull;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface TestModel {
+  @Deprecated
   String VIEW1_VIEW_NAME = "view1";
 
+  @Deprecated
   String TABLE_NAME = "test";
 
+  @Deprecated
   String A_BOOLEAN = "a_boolean";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/HockeyPlayerModel.java
@@ -9,6 +9,7 @@ import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
 import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Float;
 import java.lang.IllegalArgumentException;
@@ -22,26 +23,37 @@ import java.util.Calendar;
 import java.util.Collections;
 
 public interface HockeyPlayerModel {
+  @Deprecated
   String TABLE_NAME = "hockey_player";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String FIRST_NAME = "first_name";
 
+  @Deprecated
   String LAST_NAME = "last_name";
 
+  @Deprecated
   String NUMBER = "number";
 
+  @Deprecated
   String TEAM = "team";
 
+  @Deprecated
   String AGE = "age";
 
+  @Deprecated
   String WEIGHT = "weight";
 
+  @Deprecated
   String BIRTH_DATE = "birth_date";
 
+  @Deprecated
   String SHOOTS = "shoots";
 
+  @Deprecated
   String POSITION = "position";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/TeamModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/well-formed-selects/expected/com/sample/TeamModel.java
@@ -7,24 +7,32 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Long;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Calendar;
 
 public interface TeamModel {
+  @Deprecated
   String TABLE_NAME = "team";
 
+  @Deprecated
   String _ID = "_id";
 
+  @Deprecated
   String NAME = "name";
 
+  @Deprecated
   String FOUNDED = "founded";
 
+  @Deprecated
   String COACH = "coach";
 
+  @Deprecated
   String CAPTAIN = "captain";
 
+  @Deprecated
   String WON_CUP = "won_cup";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine-as-library/expected/com/test/UserModel.java
@@ -7,22 +7,30 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface UserModel {
+  @Deprecated
   String TABLE_NAME = "users";
 
+  @Deprecated
   String ID = "id";
 
+  @Deprecated
   String FIRST_NAME = "first_name";
 
+  @Deprecated
   String MIDDLE_INITIAL = "middle_initial";
 
+  @Deprecated
   String LAST_NAME = "last_name";
 
+  @Deprecated
   String AGE = "age";
 
+  @Deprecated
   String GENDER = "gender";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-fine/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-fine/expected/com/test/UserModel.java
@@ -7,6 +7,7 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Float;
 import java.lang.Integer;
 import java.lang.Override;
@@ -15,28 +16,40 @@ import java.util.List;
 import java.util.Map;
 
 public interface UserModel {
+  @Deprecated
   String TABLE_NAME = "users";
 
+  @Deprecated
   String ID = "id";
 
+  @Deprecated
   String FIRST_NAME = "first_name";
 
+  @Deprecated
   String MIDDLE_INITIAL = "middle_initial";
 
+  @Deprecated
   String LAST_NAME = "last_name";
 
+  @Deprecated
   String AGE = "age";
 
+  @Deprecated
   String GENDER = "gender";
 
+  @Deprecated
   String SOME_GENERIC = "some_generic";
 
+  @Deprecated
   String SOME_LIST = "some_list";
 
+  @Deprecated
   String GENDER2 = "gender2";
 
+  @Deprecated
   String FULL_USER = "full_user";
 
+  @Deprecated
   String SUCH_LIST = "such_list";
 
   String CREATE_TABLE = ""

--- a/sqldelight-gradle-plugin/src/test/fixtures/works-for-kotlin/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/works-for-kotlin/expected/com/test/UserModel.java
@@ -7,22 +7,30 @@ import com.squareup.sqldelight.ColumnAdapter;
 import com.squareup.sqldelight.RowMapper;
 import com.squareup.sqldelight.SqlDelightQuery;
 import com.squareup.sqldelight.internal.TableSet;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.String;
 
 public interface UserModel {
+  @Deprecated
   String TABLE_NAME = "users";
 
+  @Deprecated
   String ID = "id";
 
+  @Deprecated
   String FIRST_NAME = "first_name";
 
+  @Deprecated
   String MIDDLE_INITIAL = "middle_initial";
 
+  @Deprecated
   String LAST_NAME = "last_name";
 
+  @Deprecated
   String AGE = "age";
 
+  @Deprecated
   String GENDER = "gender";
 
   String CREATE_TABLE = ""


### PR DESCRIPTION
You shouldn't be using the column ones for anything, write named queries. SqlDelightQuery and SqlDelightStatement return the table(s) which they affect.