### PR TITLE
Add in an android driver with a basic test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ subprojects {
       classpath deps.kotlinGradlePlugin
       classpath deps.dokka
       classpath deps.intellijGradle
+      classpath deps.androidPlugin
     }
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,6 +4,7 @@ ext.versions = [
     idea: '2017.1',
     dokka: '0.9.15',
     archDb: '1.0.0',
+    minSdk: 14,
 ]
 
 ext.deps = [
@@ -31,8 +32,9 @@ ext.deps = [
     sqliteJdbc: "org.xerial:sqlite-jdbc:3.21.0.1",
     gradleDownload: "de.undercouch:gradle-download-task:3.4.2",
     arch: [
-        db: "android.arch.persistence:db:archDb",
-        dbFramework: "android.arch.persistence:db-framework:archDb",
+        db: "android.arch.persistence:db:${versions.archDb}",
+        dbFramework: "android.arch.persistence:db-framework:${versions.archDb}",
     ],
-    intellijGradle: "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.3.0"
+    intellijGradle: "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.3.0",
+    robolectric: 'org.robolectric:robolectric:3.5.1',
 ]

--- a/runtime/android-driver/build.gradle
+++ b/runtime/android-driver/build.gradle
@@ -1,0 +1,66 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+  compileSdkVersion versions.compileSdk
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_7
+    targetCompatibility JavaVersion.VERSION_1_7
+  }
+
+  lintOptions {
+    textReport true
+    textOutput 'stdout'
+  }
+
+  defaultConfig {
+    minSdkVersion versions.minSdk
+  }
+
+  // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
+  libraryVariants.all {
+    it.generateBuildConfig.enabled = false
+  }
+
+  testOptions {
+    unitTests.all {
+      testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+        showExceptions true
+        showStackTraces true
+        showCauses true
+      }
+    }
+  }
+}
+
+dependencies {
+  implementation deps.kotlinStdLib
+
+  api project(':runtime:sqldelight-runtime')
+  api deps.arch.db
+
+  testImplementation deps.junit
+  testImplementation deps.truth
+  testImplementation deps.robolectric
+  testImplementation deps.arch.dbFramework
+}
+
+configurations {
+  jar
+}
+android.libraryVariants.all { variant ->
+  if (variant.name != 'release') return
+
+  def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
+  task.description = "Create jar artifact for ${variant.name}"
+  task.dependsOn variant.javaCompile
+  task.from variant.javaCompile.destinationDir
+  task.destinationDir = project.file("${project.buildDir}/outputs/jar")
+  task.archiveName = "${project.name}-${variant.baseName}.jar"
+  artifacts.add('jar', task);
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/runtime/android-driver/gradle.properties
+++ b/runtime/android-driver/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=android-driver
+POM_NAME=SQLDelight Android Driver
+POM_DESCRIPTION=Driver to support SQLDelight generated code on Android
+POM_PACKAGING=aar

--- a/runtime/android-driver/src/main/AndroidManifest.xml
+++ b/runtime/android-driver/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.squareup.sqldelight"/>

--- a/runtime/android-driver/src/main/java/com/squareup/sqldelight/android/SqlDelightDatabaseHelper.kt
+++ b/runtime/android-driver/src/main/java/com/squareup/sqldelight/android/SqlDelightDatabaseHelper.kt
@@ -1,0 +1,135 @@
+package com.squareup.sqldelight.android
+
+import android.arch.persistence.db.SupportSQLiteDatabase
+import android.arch.persistence.db.SupportSQLiteOpenHelper
+import android.arch.persistence.db.SupportSQLiteProgram
+import android.arch.persistence.db.SupportSQLiteQuery
+import android.arch.persistence.db.SupportSQLiteStatement
+import android.database.Cursor
+import com.squareup.sqldelight.db.SqlDatabase
+import com.squareup.sqldelight.db.SqlDatabaseConnection
+import com.squareup.sqldelight.db.SqlPreparedStatement
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.EXEC
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE
+import com.squareup.sqldelight.db.SqlResultSet
+import java.util.ArrayDeque
+import java.util.Queue
+
+class SqlDelightDatabaseHelper(
+  private val openHelper: SupportSQLiteOpenHelper
+) : SqlDatabase {
+  override fun getConnection(): SqlDatabaseConnection {
+    return SqlDelightDatabaseConnection(openHelper.writableDatabase)
+  }
+
+  override fun close() {
+    return openHelper.close()
+  }
+}
+
+private class SqlDelightDatabaseConnection(
+  private val database: SupportSQLiteDatabase
+) : SqlDatabaseConnection {
+  override fun beginTransaction() {
+    database.beginTransactionNonExclusive()
+  }
+
+  override fun commitTransaction() {
+    database.setTransactionSuccessful()
+    database.endTransaction()
+  }
+
+  override fun rollbackTransaction() {
+    database.endTransaction()
+  }
+
+  override fun prepareStatement(sql: String, type: SqlPreparedStatement.Type) = when(type) {
+    SELECT -> SqlDelightQuery(sql, database)
+    INSERT, UPDATE, DELETE, EXEC -> SqlDelightPreparedStatement(database.compileStatement(sql), type)
+  }
+}
+
+private class SqlDelightPreparedStatement(
+  private val statement: SupportSQLiteStatement,
+  private val type: SqlPreparedStatement.Type
+) : SqlPreparedStatement {
+  override fun bindBytes(index: Int, bytes: ByteArray?) {
+    if (bytes == null) statement.bindNull(index) else statement.bindBlob(index, bytes)
+  }
+
+  override fun bindLong(index: Int, long: Long?) {
+    if (long == null) statement.bindNull(index) else statement.bindLong(index, long)
+  }
+
+  override fun bindDouble(index: Int, double: Double?) {
+    if (double == null) statement.bindNull(index) else statement.bindDouble(index, double)
+  }
+
+  override fun bindString(index: Int, string: String?) {
+    if (string == null) statement.bindNull(index) else statement.bindString(index, string)
+  }
+
+  override fun executeQuery() = throw UnsupportedOperationException()
+
+  override fun execute() = when (type) {
+    INSERT -> statement.executeInsert()
+    UPDATE, DELETE -> statement.executeUpdateDelete().toLong()
+    EXEC -> {
+      statement.execute()
+      1
+    }
+    SELECT -> throw AssertionError()
+  }
+
+}
+
+private class SqlDelightQuery(
+  private val sql: String,
+  private val database: SupportSQLiteDatabase
+) : SupportSQLiteQuery, SqlPreparedStatement {
+  val binds: Queue<(SupportSQLiteProgram) -> Unit> = ArrayDeque()
+
+  override fun bindBytes(index: Int, bytes: ByteArray?) {
+    binds.add { if (bytes == null) it.bindNull(index) else it.bindBlob(index, bytes) }
+  }
+
+  override fun bindLong(index: Int, long: Long?) {
+    binds.add { if (long == null) it.bindNull(index) else it.bindLong(index, long) }
+  }
+
+  override fun bindDouble(index: Int, double: Double?) {
+    binds.add { if (double == null) it.bindNull(index) else it.bindDouble(index, double) }
+  }
+
+  override fun bindString(index: Int, string: String?) {
+    binds.add { if (string == null) it.bindNull(index) else it.bindString(index, string) }
+  }
+
+  override fun execute() = throw UnsupportedOperationException()
+
+  override fun executeQuery() = SqlDelightResultSet(database.query(this))
+
+  override fun bindTo(statement: SupportSQLiteProgram) {
+    synchronized(binds) {
+      while (binds.isNotEmpty()) {
+        binds.poll().invoke(statement)
+      }
+    }
+  }
+
+  override fun getSql() = sql
+}
+
+private class SqlDelightResultSet(
+  private val cursor: Cursor
+) : SqlResultSet {
+  override fun next() = cursor.moveToNext()
+  override fun getString(index: Int) = cursor.getString(index)
+  override fun getLong(index: Int) = cursor.getLong(index)
+  override fun getBytes(index: Int) = cursor.getBlob(index)
+  override fun getDouble(index: Int) = cursor.getDouble(index)
+  override fun close() = cursor.close()
+}

--- a/runtime/android-driver/src/test/java/com/squareup/sqldelight/android/DriverTest.kt
+++ b/runtime/android-driver/src/test/java/com/squareup/sqldelight/android/DriverTest.kt
@@ -1,0 +1,89 @@
+package com.squareup.sqldelight.android
+
+import android.arch.persistence.db.SupportSQLiteDatabase
+import android.arch.persistence.db.SupportSQLiteOpenHelper
+import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory
+import com.google.common.truth.Truth.assertThat
+import com.squareup.sqldelight.db.SqlDatabase
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT
+import com.squareup.sqldelight.db.use
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class DriverTest {
+  private lateinit var database: SqlDatabase
+
+  @Before fun setup() {
+    val configuration = SupportSQLiteOpenHelper.Configuration.builder(RuntimeEnvironment.application)
+        .callback(object : SupportSQLiteOpenHelper.Callback(1) {
+          override fun onCreate(db: SupportSQLiteDatabase) {
+            db.execSQL("""
+              |CREATE TABLE test (
+              |  id INTEGER PRIMARY KEY,
+              |  value TEXT
+              |);
+            """.trimMargin())
+          }
+
+          override fun onUpgrade(
+            db: SupportSQLiteDatabase?,
+            oldVersion: Int,
+            newVersion: Int
+          ) {
+          }
+        })
+        .build()
+    val openHelper = FrameworkSQLiteOpenHelperFactory().create(configuration)
+    database = SqlDelightDatabaseHelper(openHelper)
+  }
+
+  @After fun tearDown() {
+    database.close()
+  }
+
+  @Test fun `insert can run multiple times`() {
+    val insert = database.getConnection().prepareStatement("INSERT INTO test VALUES (?, ?);", INSERT)
+    val query = database.getConnection().prepareStatement("SELECT * FROM test", SELECT)
+
+    query.executeQuery().use {
+      assertThat(it.next()).isFalse()
+    }
+
+    insert.bindLong(1, 1)
+    insert.bindString(2, "Alec")
+    assertThat(insert.execute()).isEqualTo(1)
+
+    query.executeQuery().use {
+      assertThat(it.next()).isTrue()
+      assertThat(it.getLong(0)).isEqualTo(1)
+      assertThat(it.getString(1)).isEqualTo("Alec")
+    }
+
+    insert.bindLong(1, 2)
+    insert.bindString(2, "Jake")
+    assertThat(insert.execute()).isEqualTo(2)
+
+    query.executeQuery().use {
+      assertThat(it.next()).isTrue()
+      assertThat(it.getLong(0)).isEqualTo(1)
+      assertThat(it.getString(1)).isEqualTo("Alec")
+      assertThat(it.next()).isTrue()
+      assertThat(it.getLong(0)).isEqualTo(2)
+      assertThat(it.getString(1)).isEqualTo("Jake")
+    }
+
+    val delete = database.getConnection().prepareStatement("DELETE FROM test", DELETE)
+    assertThat(delete.execute()).isEqualTo(2)
+
+    query.executeQuery().use {
+      assertThat(it.next()).isFalse()
+    }
+  }
+}

--- a/runtime/sqldelight-runtime/src/main/java/com/squareup/sqldelight/db/SqlDatabaseConnection.kt
+++ b/runtime/sqldelight-runtime/src/main/java/com/squareup/sqldelight/db/SqlDatabaseConnection.kt
@@ -16,7 +16,7 @@
 package com.squareup.sqldelight.db
 
 interface SqlDatabaseConnection {
-  fun prepareStatement(sql: String): SqlPreparedStatement
+  fun prepareStatement(sql: String, type: SqlPreparedStatement.Type): SqlPreparedStatement
   fun beginTransaction()
   fun commitTransaction()
   fun rollbackTransaction()

--- a/runtime/sqldelight-runtime/src/main/java/com/squareup/sqldelight/db/SqlPreparedStatement.kt
+++ b/runtime/sqldelight-runtime/src/main/java/com/squareup/sqldelight/db/SqlPreparedStatement.kt
@@ -23,4 +23,8 @@ interface SqlPreparedStatement {
 
   fun executeQuery(): SqlResultSet
   fun execute(): Long
+
+  enum class Type {
+    INSERT, UPDATE, DELETE, SELECT, EXEC
+  }
 }

--- a/runtime/sqldelight-runtime/src/test/java/com/squareup/sqldelight/QueryTest.kt
+++ b/runtime/sqldelight-runtime/src/test/java/com/squareup/sqldelight/QueryTest.kt
@@ -4,6 +4,9 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlDatabaseConnection
 import com.squareup.sqldelight.db.SqlPreparedStatement
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.EXEC
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT
 import com.squareup.sqldelight.db.SqlResultSet
 import com.squareup.sqldelight.sqlite.driver.SqliteJdbcOpenHelper
 import org.junit.After
@@ -27,9 +30,9 @@ class QueryTest {
           id INTEGER NOT NULL PRIMARY KEY,
           value TEXT NOT NULL
         );
-        """.trimIndent()).execute()
+        """.trimIndent(), EXEC).execute()
 
-    insertTestData = connection.prepareStatement("INSERT INTO test VALUES (?, ?)")
+    insertTestData = connection.prepareStatement("INSERT INTO test VALUES (?, ?)", INSERT)
   }
 
   @After fun tearDown() {
@@ -125,7 +128,7 @@ class QueryTest {
   }
 
   private fun testDataQuery(): Query<TestData> {
-    val statement = connection.prepareStatement("SELECT * FROM test")
+    val statement = connection.prepareStatement("SELECT * FROM test", SELECT)
     return Query(statement, mutableListOf(), mapper)
   }
 

--- a/runtime/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/SqliteJdbcOpenHelper.kt
+++ b/runtime/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/SqliteJdbcOpenHelper.kt
@@ -20,7 +20,7 @@ class SqliteJdbcOpenHelper : SqlDatabase {
 private class SqliteJdbcConnection(
   private val sqliteConnection: Connection
 ) : SqlDatabaseConnection {
-  override fun prepareStatement(sql: String): SqliteJdbcPreparedStatement {
+  override fun prepareStatement(sql: String, type: SqlPreparedStatement.Type): SqliteJdbcPreparedStatement {
     return SqliteJdbcPreparedStatement(sqliteConnection.prepareStatement(sql))
   }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'sqldelight'
 
+include ':runtime:android-driver'
 include ':runtime:sqldelight-runtime'
 include ':runtime:sqlite-driver'
 include ':sqldelight-core'

--- a/sqldelight-core-integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-core-integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -28,7 +28,7 @@ class PlayerQueries(
             InsertPlayer(database.getConnection().prepareStatement("""
             |INSERT INTO player
             |VALUES (?, ?, ?, ?)
-            """.trimMargin()))
+            """.trimMargin(), SqlPreparedStatement.Type.INSERT))
             }
 
     fun <T> allPlayers(mapper: (
@@ -40,7 +40,7 @@ class PlayerQueries(
         val statement = database.getConnection().prepareStatement("""
                 |SELECT *
                 |FROM player
-                """.trimMargin())
+                """.trimMargin(), SqlPreparedStatement.Type.SELECT)
         return Query(statement, allPlayers) { resultSet ->
             mapper(
                 resultSet.getString(0)!!,
@@ -63,7 +63,7 @@ class PlayerQueries(
                 |SELECT *
                 |FROM player
                 |WHERE team = ?1
-                """.trimMargin())
+                """.trimMargin(), SqlPreparedStatement.Type.SELECT)
         statement.bindString(1, team)
         return PlayersForTeam(team, statement) { resultSet ->
             mapper(
@@ -90,7 +90,7 @@ class PlayerQueries(
                 |SELECT *
                 |FROM player
                 |WHERE number IN $numberIndexes
-                """.trimMargin())
+                """.trimMargin(), SqlPreparedStatement.Type.SELECT)
         number.forEachIndexed { index, number ->
                 statement.bindLong(index + 2, number)
                 }
@@ -121,7 +121,7 @@ class PlayerQueries(
                 |UPDATE player
                 |SET team = ?1
                 |WHERE number IN $numberIndexes
-                """.trimMargin())
+                """.trimMargin(), SqlPreparedStatement.Type.UPDATE)
         statement.bindString(1, team)
         number.forEachIndexed { index, number ->
                 statement.bindLong(index + 3, number)

--- a/sqldelight-core-integration-tests/src/test/kotlin/com/example/QueryWrapper.kt
+++ b/sqldelight-core-integration-tests/src/test/kotlin/com/example/QueryWrapper.kt
@@ -3,6 +3,7 @@ package com.example
 import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlDatabaseConnection
+import com.squareup.sqldelight.db.SqlPreparedStatement
 import java.lang.ThreadLocal
 
 class QueryWrapper(database: SqlDatabase, internal val playerAdapter: Player.Adapter) {
@@ -20,12 +21,12 @@ class QueryWrapper(database: SqlDatabase, internal val playerAdapter: Player.Ada
                     |  captain INTEGER UNIQUE NOT NULL REFERENCES player(number),
                     |  coach TEXT NOT NULL
                     |)
-                    """.trimMargin()).execute()
+                    """.trimMargin(), SqlPreparedStatement.Type.EXEC).execute()
             db.prepareStatement("""
                     |INSERT INTO team
                     |VALUES ('Anaheim Ducks', 10, 'Randy Carlyle'),
                     |       ('Ottawa Senators', 65, 'Guy Boucher')
-                    """.trimMargin()).execute()
+                    """.trimMargin(), SqlPreparedStatement.Type.EXEC).execute()
             db.prepareStatement("""
                     |CREATE TABLE player (
                     |  name TEXT NOT NULL,
@@ -34,12 +35,12 @@ class QueryWrapper(database: SqlDatabase, internal val playerAdapter: Player.Ada
                     |  shoots TEXT NOT NULL,
                     |  PRIMARY KEY (team, number)
                     |)
-                    """.trimMargin()).execute()
+                    """.trimMargin(), SqlPreparedStatement.Type.EXEC).execute()
             db.prepareStatement("""
                     |INSERT INTO player
                     |VALUES ('Ryan Getzlaf', 10, 'Anaheim Ducks', 'RIGHT'),
                     |       ('Erik Karlsson', 65, 'Ottawa Senators', 'RIGHT')
-                    """.trimMargin()).execute()
+                    """.trimMargin(), SqlPreparedStatement.Type.EXEC).execute()
         }
     }
 }

--- a/sqldelight-core-integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-core-integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -27,7 +27,7 @@ class TeamQueries(
                 |SELECT *
                 |FROM team
                 |WHERE coach = ?1
-                """.trimMargin())
+                """.trimMargin(), SqlPreparedStatement.Type.SELECT)
         statement.bindString(1, coach)
         return TeamForCoach(coach, statement) { resultSet ->
             mapper(

--- a/sqldelight-core/build.gradle
+++ b/sqldelight-core/build.gradle
@@ -19,6 +19,16 @@ grammarKit {
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
+test {
+  testLogging {
+    events "passed", "skipped", "failed"
+    exceptionFormat "full"
+    showExceptions true
+    showStackTraces true
+    showCauses true
+  }
+}
+
 sourceSets {
   main.java.srcDir "src/generated/kotlin"
 }

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/MutatorQueryGenerator.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/MutatorQueryGenerator.kt
@@ -60,8 +60,8 @@ class MutatorQueryGenerator(
     return PropertySpec.builder(query.name, ClassName("", query.name.capitalize()), PRIVATE)
         .delegate("""
           |lazy {
-          |${query.name.capitalize()}($DATABASE_NAME.getConnection().prepareStatement(%S))
-          |}""".trimMargin(), query.statement.rawSqlText())
+          |${query.name.capitalize()}($DATABASE_NAME.getConnection().prepareStatement(%S, %L))
+          |}""".trimMargin(), query.statement.rawSqlText(), query.type())
         .build()
   }
 

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryGenerator.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryGenerator.kt
@@ -22,7 +22,7 @@ abstract class QueryGenerator(private val query: BindableQuery) {
    *     |SELECT *
    *     |FROM player
    *     |WHERE number IN $numberIndexes
-   *     """.trimMargin())
+   *     """.trimMargin(), SqlPreparedStatement.Type.SELECT)
    * number.forEachIndexed { index, number ->
    *     statement.bindLong(index + 2, number)
    *     }
@@ -78,8 +78,8 @@ abstract class QueryGenerator(private val query: BindableQuery) {
     // Adds the actual SqlPreparedStatement:
     // statement = database.getConnection().prepareStatement("SELECT * FROM test")
     result.addStatement(
-        "val $STATEMENT_NAME = $DATABASE_NAME.getConnection().prepareStatement(%S)",
-        query.statement.rawSqlText(replacements)
+        "val $STATEMENT_NAME = $DATABASE_NAME.getConnection().prepareStatement(%S, %L)",
+        query.statement.rawSqlText(replacements), query.type()
     )
     result.add(bindStatements.build())
 

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryWrapperGenerator.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryWrapperGenerator.kt
@@ -32,6 +32,7 @@ import com.squareup.sqldelight.core.lang.CONNECTION_TYPE
 import com.squareup.sqldelight.core.lang.DATABASE_NAME
 import com.squareup.sqldelight.core.lang.DATABASE_TYPE
 import com.squareup.sqldelight.core.lang.QUERY_WRAPPER_NAME
+import com.squareup.sqldelight.core.lang.STATEMENT_TYPE_ENUM
 import com.squareup.sqldelight.core.lang.SqlDelightFile
 import com.squareup.sqldelight.core.lang.THREADLOCAL_TYPE
 import com.squareup.sqldelight.core.lang.TRANSACTIONS_NAME
@@ -83,10 +84,10 @@ internal class QueryWrapperGenerator(module: Module) {
             if (label.name != null) return@statements
 
             // Unlabeled statements are run during onCreate callback:
-            // db.prepareStatement("CREATE TABLE ... ").execute()
+            // db.prepareStatement("CREATE TABLE ... ", Type.EXEC).execute()
             onCreateFunction.addStatement(
-                "$CONNECTION_NAME.prepareStatement(%S).execute()",
-                sqliteStatement.rawSqlText()
+                "$CONNECTION_NAME.prepareStatement(%S, %T.EXEC).execute()",
+                sqliteStatement.rawSqlText(), STATEMENT_TYPE_ENUM
             )
 
             sqliteStatement.createTableStmt?.let {

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
@@ -19,6 +19,7 @@ import com.alecstrong.sqlite.psi.core.psi.SqliteBindExpr
 import com.alecstrong.sqlite.psi.core.psi.SqliteCreateTableStmt
 import com.alecstrong.sqlite.psi.core.psi.SqliteTypes
 import com.intellij.psi.PsiElement
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.sqldelight.core.lang.IntermediateType
 import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.ARGUMENT
 import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.NULL
@@ -30,7 +31,7 @@ import com.squareup.sqldelight.core.lang.util.findChildrenOfType
 import com.squareup.sqldelight.core.lang.util.interfaceType
 import com.squareup.sqldelight.core.lang.util.table
 
-open class BindableQuery(
+abstract class BindableQuery(
   internal val identifier: PsiElement?,
   internal val statement: PsiElement
 ) {
@@ -130,6 +131,8 @@ open class BindableQuery(
         .dropWhile(String::isEmpty)
         .joinToString(separator = "\n", transform = String::trim)
   }
+
+  internal abstract fun type(): CodeBlock
 
   companion object {
     /**

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedMutator.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedMutator.kt
@@ -21,6 +21,8 @@ import com.alecstrong.sqlite.psi.core.psi.SqliteInsertStmt
 import com.alecstrong.sqlite.psi.core.psi.SqliteTableName
 import com.alecstrong.sqlite.psi.core.psi.SqliteUpdateStmtLimited
 import com.intellij.psi.PsiElement
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.sqldelight.core.lang.STATEMENT_TYPE_ENUM
 import com.squareup.sqldelight.core.lang.psi.StmtIdentifierMixin
 import com.squareup.sqldelight.core.lang.util.referencedTables
 
@@ -38,15 +40,21 @@ sealed class NamedMutator(
   class Insert(
     insert: SqliteInsertStmt,
     identifier: StmtIdentifierMixin
-  ) : NamedMutator(insert, identifier, insert.tableName)
+  ) : NamedMutator(insert, identifier, insert.tableName) {
+    override fun type() = CodeBlock.of("%T.INSERT", STATEMENT_TYPE_ENUM)
+  }
 
   class Delete(
     delete: SqliteDeleteStmtLimited,
     identifier: StmtIdentifierMixin
-  ) : NamedMutator(delete, identifier, delete.qualifiedTableName.tableName)
+  ) : NamedMutator(delete, identifier, delete.qualifiedTableName.tableName) {
+    override fun type() = CodeBlock.of("%T.DELETE", STATEMENT_TYPE_ENUM)
+  }
 
   class Update(
     update: SqliteUpdateStmtLimited,
     identifier: StmtIdentifierMixin
-  ) : NamedMutator(update, identifier, update.qualifiedTableName.tableName)
+  ) : NamedMutator(update, identifier, update.qualifiedTableName.tableName) {
+    override fun type() = CodeBlock.of("%T.UPDATE", STATEMENT_TYPE_ENUM)
+  }
 }

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
@@ -34,6 +34,7 @@ import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.NULL
 import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.REAL
 import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.QUERY_WRAPPER_NAME
+import com.squareup.sqldelight.core.lang.STATEMENT_TYPE_ENUM
 import com.squareup.sqldelight.core.lang.queriesName
 import com.squareup.sqldelight.core.lang.util.name
 import com.squareup.sqldelight.core.lang.util.sqFile
@@ -112,6 +113,8 @@ data class NamedQuery(
 
   internal val queryProperty =
       CodeBlock.of("$QUERY_WRAPPER_NAME.${select.sqFile().queriesName}.$name")
+
+  override fun type() = CodeBlock.of("%T.SELECT", STATEMENT_TYPE_ENUM)
 
   private fun resultColumns(valuesList: List<SqliteValuesExpression>): List<IntermediateType> {
     return valuesList.fold(emptyList(), { results, values ->

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
@@ -19,6 +19,7 @@ internal val SqliteCreateTableStmt.adapterName
 
 internal val STATEMENT_NAME = "statement"
 internal val STATEMENT_TYPE = ClassName("com.squareup.sqldelight.db", "SqlPreparedStatement")
+internal val STATEMENT_TYPE_ENUM = STATEMENT_TYPE.nestedClass("Type")
 
 internal val QUERY_TYPE = ClassName("com.squareup.sqldelight", "Query")
 
@@ -43,3 +44,4 @@ internal val THREADLOCAL_TYPE = ThreadLocal::class.asClassName()
 
 internal val CONNECTION_TYPE = ClassName("com.squareup.sqldelight.db", "SqlDatabaseConnection")
 internal val CONNECTION_NAME = "db"
+

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -56,7 +56,7 @@ class QueriesTypeTest {
       |            InsertData(database.getConnection().prepareStatement(""${'"'}
       |            |INSERT INTO data
       |            |VALUES (?, ?)
-      |            ""${'"'}.trimMargin()))
+      |            ""${'"'}.trimMargin(), SqlPreparedStatement.Type.INSERT))
       |            }
       |
       |    fun <T> selectForId(id: Long, mapper: (id: Long, value: List?) -> T): Query<T> {
@@ -64,7 +64,7 @@ class QueriesTypeTest {
       |                |SELECT *
       |                |FROM data
       |                |WHERE id = ?1
-      |                ""${'"'}.trimMargin())
+      |                ""${'"'}.trimMargin(), SqlPreparedStatement.Type.SELECT)
       |        statement.bindLong(1, id)
       |        return SelectForId(id, statement) { resultSet ->
       |            mapper(

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueryWrapperTest.kt
@@ -31,6 +31,7 @@ class QueryWrapperTest {
       |import com.squareup.sqldelight.Transacter
       |import com.squareup.sqldelight.db.SqlDatabase
       |import com.squareup.sqldelight.db.SqlDatabaseConnection
+      |import com.squareup.sqldelight.db.SqlPreparedStatement
       |import java.lang.ThreadLocal
       |
       |class QueryWrapper(database: SqlDatabase) {
@@ -45,11 +46,11 @@ class QueryWrapperTest {
       |                    |  _id INTEGER NOT NULL PRIMARY KEY,
       |                    |  value TEXT
       |                    |)
-      |                    ""${'"'}.trimMargin()).execute()
+      |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXEC).execute()
       |            db.prepareStatement(""${'"'}
       |                    |INSERT INTO test_table
       |                    |VALUES (1, 'test')
-      |                    ""${'"'}.trimMargin()).execute()
+      |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXEC).execute()
       |        }
       |    }
       |}
@@ -75,13 +76,13 @@ class QueryWrapperTest {
 
     val queryWrapperFile = result.compilerOutput[File(result.outputDirectory, "com/example/QueryWrapper.kt")]
     assertThat(queryWrapperFile).isNotNull()
-    assertThat(queryWrapperFile.toString()).isEqualTo(
-        """
+    assertThat(queryWrapperFile.toString()).isEqualTo("""
         |package com.example
         |
         |import com.squareup.sqldelight.Transacter
         |import com.squareup.sqldelight.db.SqlDatabase
         |import com.squareup.sqldelight.db.SqlDatabaseConnection
+        |import com.squareup.sqldelight.db.SqlPreparedStatement
         |import java.lang.ThreadLocal
         |
         |class QueryWrapper(
@@ -100,13 +101,13 @@ class QueryWrapperTest {
         |                    |  _id INTEGER NOT NULL PRIMARY KEY,
         |                    |  value TEXT
         |                    |)
-        |                    ""${'"'}.trimMargin()).execute()
+        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXEC).execute()
         |            db.prepareStatement(""${'"'}
         |                    |CREATE TABLE test_table2(
         |                    |  _id INTEGER NOT NULL PRIMARY KEY,
         |                    |  value TEXT
         |                    |)
-        |                    ""${'"'}.trimMargin()).execute()
+        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXEC).execute()
         |        }
         |    }
         |}

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -48,7 +48,7 @@ class MutatorQueryFunctionTest {
       |        InsertData(database.getConnection().prepareStatement(""${'"'}
       |        |INSERT INTO data
       |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin()))
+      |        ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT))
       |        }
       |""".trimMargin())
   }
@@ -72,7 +72,7 @@ class MutatorQueryFunctionTest {
       |        InsertData(database.getConnection().prepareStatement(""${'"'}
       |        |INSERT INTO data
       |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin()))
+      |        ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT))
       |        }
       |""".trimMargin())
   }
@@ -178,7 +178,7 @@ class MutatorQueryFunctionTest {
       |            |UPDATE data
       |            |SET value = ?1
       |            |WHERE id IN ${"$"}idIndexes
-      |            ""${'"'}.trimMargin())
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE)
       |    statement.bindString(1, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
       |    id.forEachIndexed { index, id ->
       |            statement.bindLong(index + 3, id)

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -49,7 +49,7 @@ class SelectQueryFunctionTest {
     |            |SELECT *
     |            |FROM data
     |            |WHERE id = ?1
-    |            ""${'"'}.trimMargin())
+    |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT)
     |    statement.bindLong(1, id)
     |    return SelectForId(id, statement) { resultSet ->
     |        mapper(
@@ -84,7 +84,7 @@ class SelectQueryFunctionTest {
       |            |SELECT *
       |            |FROM data
       |            |WHERE id = ?1
-      |            ""${'"'}.trimMargin())
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT)
       |    statement.bindLong(1, id)
       |    return SelectForId(id, statement) { resultSet ->
       |        mapper(
@@ -129,7 +129,7 @@ class SelectQueryFunctionTest {
       |    val statement = database.getConnection().prepareStatement(""${'"'}
       |            |SELECT *
       |            |FROM data
-      |            ""${'"'}.trimMargin())
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT)
       |    return com.squareup.sqldelight.Query(statement, selectForId) { resultSet ->
       |        mapper(
       |            resultSet.getLong(0)!!,
@@ -162,7 +162,7 @@ class SelectQueryFunctionTest {
       |    val statement = database.getConnection().prepareStatement(""${'"'}
       |            |SELECT *
       |            |FROM data
-      |            ""${'"'}.trimMargin())
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT)
       |    return com.squareup.sqldelight.Query(statement, selectData) { resultSet ->
       |        resultSet.getLong(0)!!
       |    }
@@ -196,7 +196,7 @@ class SelectQueryFunctionTest {
       |            |SELECT *
       |            |FROM data
       |            |WHERE id IN ${"$"}goodIndexes AND id NOT IN ${"$"}badIndexes
-      |            ""${'"'}.trimMargin())
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT)
       |    good.forEachIndexed { index, good ->
       |            statement.bindLong(index + 3, good)
       |            }
@@ -252,7 +252,7 @@ class SelectQueryFunctionTest {
       |    val statement = database.getConnection().prepareStatement(""${'"'}
       |            |SELECT *
       |            |FROM data
-      |            ""${'"'}.trimMargin())
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT)
       |    return com.squareup.sqldelight.Query(statement, selectData) { resultSet ->
       |        mapper(
       |            resultSet.getLong(0)!!,


### PR DESCRIPTION
Had to change the signature of `prepareStatement(sql: String)` to also take a statement type since the android runtime prepares selects differently from mutators. Low cost change but touched a lot of files/tests