### PR TITLE
Add in rxjava2 extensions module + tests

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,7 +35,6 @@ ext.deps = [
     truth: 'com.google.truth:truth:0.30',
     bugsnag: 'com.bugsnag:bugsnag:2.0.0',
     jps: "JPS-${versions.idea}",
-    okio: 'com.squareup.okio:okio:1.11.0',
     intellijCore: fileTree(dir: '../lib/intellij-core/lib', include: [
         'idea.jar', 'openapi.jar', 'util.jar', 'trove4j.jar', 'extensions.jar',
         'picocontainer.jar', 'asm-all.jar', 'guava-19.0.jar', 'automaton.jar'
@@ -50,4 +49,5 @@ ext.deps = [
     robolectric: 'org.robolectric:robolectric:3.5.1',
     autoValue: "com.google.auto.value:auto-value:$versions.autoValue",
     autoValueAnnotations: "com.jakewharton.auto.value:auto-value-annotations:$versions.autoValueAnnotations",
+    rxJava2: "io.reactivex.rxjava2:rxjava:2.1.12"
 ]

--- a/runtime/rxjava2-extensions/build.gradle
+++ b/runtime/rxjava2-extensions/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'kotlin'
+
+dependencies {
+  implementation project(':runtime:sqldelight-runtime')
+  implementation deps.kotlin.stdlib
+  implementation deps.rxJava2
+
+  testImplementation project(':runtime:sqlite-driver')
+  testImplementation deps.junit
+  testImplementation deps.truth
+}
+
+apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/runtime/rxjava2-extensions/gradle.properties
+++ b/runtime/rxjava2-extensions/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=rxjava2-extensions
+POM_NAME=SQLDelight RxJava2 Extensions
+POM_DESCRIPTION=Kotlin extension functions to expose SQLDelight Querys as ObservableSources
+POM_PACKAGING=jar

--- a/runtime/rxjava2-extensions/src/main/kotlin/com/squareup/sqldelight/runtime/rx/QueryObservable.kt
+++ b/runtime/rxjava2-extensions/src/main/kotlin/com/squareup/sqldelight/runtime/rx/QueryObservable.kt
@@ -1,0 +1,87 @@
+package com.squareup.sqldelight.runtime.rx
+
+import com.squareup.sqldelight.Query
+import io.reactivex.Observable
+import io.reactivex.Observer
+import io.reactivex.Scheduler
+import io.reactivex.annotations.CheckReturnValue
+import io.reactivex.disposables.Disposable
+import io.reactivex.schedulers.Schedulers
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Turns this [Query] into an [Observable] which emits whenever the underlying result set changes.
+ *
+ * ### Scheduler:
+ *   [observe] by default operates on the [io.reactivex.schedulers.Schedulers.io] scheduler but can
+ *   be optionally overridden with [scheduler]
+ */
+@CheckReturnValue
+fun <T : Any> Query<T>.observe(scheduler: Scheduler = Schedulers.io()): QueryObservable<T> {
+  return QueryObservable(this, scheduler)
+}
+
+class QueryObservable<RowType : Any>(
+  private val query: Query<RowType>,
+  private val scheduler: Scheduler
+) : Observable<Query<RowType>>() {
+  override fun subscribeActual(observer: Observer<in Query<RowType>>) {
+    val listener = Listener(query, observer, scheduler)
+    observer.onSubscribe(listener)
+    query.addListener(listener)
+    listener.queryResultsChanged()
+  }
+
+  @CheckReturnValue
+  fun mapToOne(): Observable<RowType> {
+    return map { it.executeAsOne() }
+  }
+
+  @CheckReturnValue
+  fun mapToOneOrDefault(defaultValue: RowType): Observable<RowType> {
+    return map { it.executeAsOneOrNull() ?: defaultValue }
+  }
+
+  @CheckReturnValue
+  fun mapToOptional(): Observable<Optional<RowType>> {
+    return map { Optional.ofNullable(it.executeAsOneOrNull()) }
+  }
+
+  @CheckReturnValue
+  fun mapToList(): Observable<List<RowType>> {
+    return map { it.executeAsList() }
+  }
+
+  @CheckReturnValue
+  fun mapToOneNonNull(): Observable<RowType> {
+    return flatMap {
+      val result = it.executeAsOneOrNull()
+      if (result == null) Observable.empty() else Observable.just(result)
+    }
+  }
+}
+
+private class Listener<RowType : Any>(
+    private val query: Query<RowType>,
+    private val observer: Observer<in Query<RowType>>,
+    private val scheduler: Scheduler
+) : Query.Listener, Disposable {
+  private val unsubscribed = AtomicBoolean()
+
+  override fun isDisposed() = unsubscribed.get()
+
+  override fun dispose() {
+    if (unsubscribed.compareAndSet(false, true)) {
+      query.removeListener(this)
+    }
+  }
+
+  override fun queryResultsChanged() {
+    if (!isDisposed) {
+      scheduler.scheduleDirect {
+        observer.onNext(query)
+      }
+    }
+  }
+}

--- a/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/ObservingTest.kt
+++ b/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/ObservingTest.kt
@@ -1,0 +1,130 @@
+package com.squareup.sqldelight.runtime.rx
+
+import com.squareup.sqldelight.runtime.rx.Employee.Companion.MAPPER
+import com.squareup.sqldelight.runtime.rx.Employee.Companion.SELECT_EMPLOYEES
+import com.squareup.sqldelight.runtime.rx.TestDb.Companion.TABLE_EMPLOYEE
+import io.reactivex.schedulers.Schedulers
+import io.reactivex.schedulers.TestScheduler
+import io.reactivex.subjects.PublishSubject
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class ObservingTest {
+  private val o = RecordingObserver()
+  private val scheduler = TestScheduler()
+
+  private lateinit var db: TestDb
+
+  @Before fun setup() {
+    db = TestDb()
+  }
+
+  @After fun tearDown() {
+    o.assertNoMoreEvents()
+    db.close()
+  }
+
+  @Test fun query() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
+        .observe(Schedulers.trampoline())
+        .subscribe(o)
+    o.assertResultSet()
+        .hasRow("alice", "Alice Allison")
+        .hasRow("bob", "Bob Bobberson")
+        .hasRow("eve", "Eve Evenson")
+        .isExhausted()
+  }
+
+  @Test fun `query observes notification`() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
+        .observe(Schedulers.trampoline())
+        .subscribe(o)
+    o.assertResultSet()
+        .hasRow("alice", "Alice Allison")
+        .hasRow("bob", "Bob Bobberson")
+        .hasRow("eve", "Eve Evenson")
+        .isExhausted()
+
+    db.employee(Employee("john", "John Johnson"))
+    o.assertResultSet()
+        .hasRow("alice", "Alice Allison")
+        .hasRow("bob", "Bob Bobberson")
+        .hasRow("eve", "Eve Evenson")
+        .hasRow("john", "John Johnson")
+        .isExhausted()
+  }
+
+  @Test fun queryInitialValueAndTriggerUsesScheduler() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER).observe(scheduler).subscribe(o)
+    o.assertNoMoreEvents()
+    scheduler.triggerActions()
+    o.assertResultSet()
+        .hasRow("alice", "Alice Allison")
+        .hasRow("bob", "Bob Bobberson")
+        .hasRow("eve", "Eve Evenson")
+        .isExhausted()
+
+    db.employee(Employee("john", "John Johnson"))
+    o.assertNoMoreEvents()
+    scheduler.triggerActions()
+    o.assertResultSet()
+        .hasRow("alice", "Alice Allison")
+        .hasRow("bob", "Bob Bobberson")
+        .hasRow("eve", "Eve Evenson")
+        .hasRow("john", "John Johnson")
+        .isExhausted()
+  }
+
+  @Test fun queryNotNotifiedWhenQueryTransformerUnsubscribes() {
+    val killSwitch = PublishSubject.create<Any>()
+
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
+        .observe(Schedulers.trampoline())
+        .takeUntil(killSwitch)
+        .subscribe(o)
+    o.assertResultSet()
+        .hasRow("alice", "Alice Allison")
+        .hasRow("bob", "Bob Bobberson")
+        .hasRow("eve", "Eve Evenson")
+        .isExhausted()
+
+    killSwitch.onNext("kill")
+    o.assertIsCompleted()
+
+    db.employee(Employee("john", "John Johnson"))
+    o.assertNoMoreEvents()
+  }
+
+  @Test fun queryNotNotifiedAfterDispose() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
+        .observe(Schedulers.trampoline())
+        .subscribe(o)
+    o.assertResultSet()
+        .hasRow("alice", "Alice Allison")
+        .hasRow("bob", "Bob Bobberson")
+        .hasRow("eve", "Eve Evenson")
+        .isExhausted()
+    o.dispose()
+
+    db.employee(Employee("john", "John Johnson"))
+    o.assertNoMoreEvents()
+  }
+
+  @Test fun queryOnlyNotifiedAfterSubscribe() {
+    val query = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
+        .observe(Schedulers.trampoline())
+    o.assertNoMoreEvents()
+
+    db.employee(Employee("john", "John Johnson"))
+    o.assertNoMoreEvents()
+
+    query.subscribe(o)
+    o.assertResultSet()
+        .hasRow("alice", "Alice Allison")
+        .hasRow("bob", "Bob Bobberson")
+        .hasRow("eve", "Eve Evenson")
+        .hasRow("john", "John Johnson")
+        .isExhausted()
+  }
+}

--- a/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/QueryObservableTest.kt
+++ b/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/QueryObservableTest.kt
@@ -1,0 +1,49 @@
+package com.squareup.sqldelight.runtime.rx
+
+import com.squareup.sqldelight.Query
+import com.squareup.sqldelight.db.SqlPreparedStatement
+import com.squareup.sqldelight.db.SqlResultSet
+import com.squareup.sqldelight.runtime.rx.Employee.Companion.SELECT_EMPLOYEES
+import com.squareup.sqldelight.runtime.rx.TestDb.Companion.TABLE_EMPLOYEE
+import io.reactivex.schedulers.Schedulers
+import org.junit.Test
+
+class QueryObservableTest {
+  @Test fun mapToListThrowsFromQueryRun() {
+    val error = IllegalStateException("test exception")
+    val preparedStatement = object : SqlPreparedStatement {
+      override fun bindBytes(index: Int, bytes: ByteArray?) = throw AssertionError()
+      override fun bindLong(index: Int, long: Long?) = throw AssertionError()
+      override fun bindDouble(index: Int, double: Double?) = throw AssertionError()
+      override fun bindString(index: Int, string: String?) = throw AssertionError()
+      override fun execute() = throw AssertionError()
+
+      override fun executeQuery(): SqlResultSet {
+        throw error
+      }
+    }
+
+    val query = Query<Any>(preparedStatement, mutableListOf(), {
+      throw AssertionError("Must not be called")
+    })
+
+    query.observe(Schedulers.trampoline()).mapToList()
+        .test()
+        .assertNoValues()
+        .assertError(error)
+  }
+
+  @Test fun mapToListThrowsFromMapFunction() {
+    val db = TestDb()
+    val error = IllegalStateException("test exception")
+
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, { throw error })
+        .observe(Schedulers.trampoline())
+        .mapToList()
+        .test()
+        .assertNoValues()
+        .assertError(error)
+
+    db.close()
+  }
+}

--- a/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/QueryTest.kt
+++ b/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/QueryTest.kt
@@ -1,0 +1,124 @@
+package com.squareup.sqldelight.runtime.rx
+
+import com.squareup.sqldelight.runtime.rx.Employee.Companion.MAPPER
+import com.squareup.sqldelight.runtime.rx.Employee.Companion.SELECT_EMPLOYEES
+import com.squareup.sqldelight.runtime.rx.TestDb.Companion.TABLE_EMPLOYEE
+import io.reactivex.schedulers.Schedulers
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.Optional
+
+class QueryTest {
+  private lateinit var db: TestDb
+
+  @Before fun setup() {
+    db = TestDb()
+  }
+
+  @After fun tearDown() {
+    db.close()
+  }
+
+  @Test fun mapToOne() {
+    db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", MAPPER)
+        .observe(Schedulers.trampoline())
+        .mapToOne()
+        .test()
+        .assertValue(Employee("alice", "Alice Allison"))
+  }
+
+  @Test fun `mapToOne throws on multiple rows`() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 2", MAPPER)
+        .observe(Schedulers.trampoline())
+        .mapToOne()
+        .test()
+        .assertErrorMessage("Cursor returned more than 1 row")
+  }
+
+  @Test fun mapToOneOrDefault() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 1", MAPPER)
+        .observe(Schedulers.trampoline())
+        .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
+        .test()
+        .assertValue(Employee("alice", "Alice Allison"))
+  }
+
+  @Test fun `mapToOneOrDefault throws on multiple rows`() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 2", MAPPER) //
+        .observe(Schedulers.trampoline())
+        .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
+        .test()
+        .assertErrorMessage("Cursor returned more than 1 row")
+  }
+
+  @Test fun `mapToOneOrDefault returns default when no results`() {
+    val defaultEmployee = Employee("fred", "Fred Frederson")
+
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 0", MAPPER) //
+        .observe(Schedulers.trampoline())
+        .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
+        .test()
+        .assertValue(defaultEmployee)
+  }
+
+  @Test fun mapToList() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
+        .observe(Schedulers.trampoline())
+        .mapToList()
+        .test()
+        .assertValue(listOf(
+            Employee("alice", "Alice Allison"), //
+            Employee("bob", "Bob Bobberson"), //
+            Employee("eve", "Eve Evenson")
+        ))
+  }
+
+  @Test fun `mapToList empty when no rows`() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " WHERE 1=2", MAPPER)
+        .observe(Schedulers.trampoline())
+        .mapToList()
+        .test()
+        .assertValue(emptyList())
+  }
+
+  @Test fun mapToOptional() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 1", MAPPER)
+        .observe(Schedulers.trampoline())
+        .mapToOptional()
+        .test()
+        .assertValue(Optional.of(Employee("alice", "Alice Allison")))
+  }
+
+  @Test fun `mapToOptional throws on multiple rows`() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 2", MAPPER) //
+        .observe(Schedulers.trampoline())
+        .mapToOptional()
+        .test()
+        .assertErrorMessage("Cursor returned more than 1 row")
+  }
+
+  @Test fun `mapToOptional empty when no results`() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 0", MAPPER) //
+        .observe(Schedulers.trampoline())
+        .mapToOptional()
+        .test()
+        .assertValue(Optional.empty())
+  }
+
+  @Test fun mapToOneNonNull() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 1", MAPPER)
+        .observe(Schedulers.trampoline())
+        .mapToOneNonNull()
+        .test()
+        .assertValue(Employee("alice", "Alice Allison"))
+  }
+
+  @Test fun `mapToOneNonNull doesnt emit for no results`() {
+    db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES + " LIMIT 0", MAPPER)
+        .observe(Schedulers.trampoline())
+        .mapToOneNonNull()
+        .test()
+        .assertNoValues()
+  }
+}

--- a/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/RecordingObserver.kt
+++ b/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/RecordingObserver.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqldelight.runtime.rx
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.sqldelight.Query
+import com.squareup.sqldelight.db.SqlResultSet
+import io.reactivex.observers.DisposableObserver
+import java.util.concurrent.BlockingDeque
+import java.util.concurrent.LinkedBlockingDeque
+
+internal class RecordingObserver : DisposableObserver<Query<*>>() {
+
+  val events: BlockingDeque<Any> = LinkedBlockingDeque()
+
+  override fun onComplete() {
+    events.add(COMPLETED)
+  }
+
+  override fun onError(e: Throwable) {
+    events.add(e)
+  }
+
+  override fun onNext(value: Query<*>) {
+    events.add(value.execute())
+  }
+
+  fun takeEvent(): Any {
+    return events.removeFirst() ?: throw AssertionError("No items.")
+  }
+
+  fun assertResultSet(): ResultSetAssert {
+    val event = takeEvent()
+    assertThat(event).isInstanceOf(SqlResultSet::class.java)
+    return ResultSetAssert(event as SqlResultSet)
+  }
+
+  fun assertErrorContains(expected: String) {
+    val event = takeEvent()
+    assertThat(event).isInstanceOf(Throwable::class.java)
+    assertThat((event as Throwable).message).contains(expected)
+  }
+
+  fun assertIsCompleted() {
+    val event = takeEvent()
+    assertThat(event).isEqualTo(COMPLETED)
+  }
+
+  fun assertNoMoreEvents() {
+    assertThat(events).isEmpty()
+  }
+
+  internal class ResultSetAssert(private val resultSet: SqlResultSet) {
+    private var row = 0
+
+    fun hasRow(vararg values: Any): ResultSetAssert {
+      assertThat(resultSet.next()).named("row ${row + 1} exists").isTrue()
+      row += 1
+      for (i in values.indices) {
+        assertThat(resultSet.getString(i))
+            .named("row $row column '$i'")
+            .isEqualTo(values[i])
+      }
+      return this
+    }
+
+    fun isExhausted() {
+      if (resultSet.next()) {
+        throw AssertionError("Expected no more rows but was")
+      }
+      resultSet.close()
+    }
+  }
+
+  companion object {
+    private val COMPLETED = "<completed>"
+  }
+}

--- a/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/TestDb.kt
+++ b/runtime/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/TestDb.kt
@@ -1,0 +1,122 @@
+package com.squareup.sqldelight.runtime.rx
+
+import com.squareup.sqldelight.Query
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.EXEC
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT
+import com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT
+import com.squareup.sqldelight.db.SqlResultSet
+import com.squareup.sqldelight.runtime.rx.TestDb.Companion.TABLE_EMPLOYEE
+import com.squareup.sqldelight.runtime.rx.TestDb.Companion.TABLE_MANAGER
+import com.squareup.sqldelight.sqlite.driver.SqliteJdbcOpenHelper
+
+class TestDb {
+  val helper = SqliteJdbcOpenHelper()
+  val db = helper.getConnection()
+  val queries = mutableMapOf<String, MutableList<Query<*>>>()
+
+  var aliceId: Long = 0
+  var bobId: Long = 0
+  var eveId: Long = 0
+
+  init {
+    db.prepareStatement("PRAGMA foreign_keys=ON", EXEC).execute()
+
+    db.prepareStatement(CREATE_EMPLOYEE, EXEC).execute()
+    aliceId = employee(Employee("alice", "Alice Allison"))
+    bobId = employee(Employee("bob", "Bob Bobberson"))
+    eveId = employee(Employee("eve", "Eve Evenson"))
+
+    db.prepareStatement(CREATE_MANAGER, EXEC).execute()
+    manager(eveId, aliceId)
+  }
+
+  fun <T: Any> createQuery(key: String, query: String, mapper: (SqlResultSet) -> T): Query<T> {
+    val statement = db.prepareStatement(query, SELECT)
+    return Query(statement, queries.getOrPut(key, { mutableListOf() }), mapper)
+  }
+
+  fun notify(key: String) {
+    queries[key]?.forEach { it.notifyResultSetChanged() }
+  }
+
+  fun close() {
+    helper.close()
+  }
+
+  fun employee(employee: Employee): Long {
+    val statement = db.prepareStatement("""
+      |INSERT OR FAIL INTO $TABLE_EMPLOYEE (${Employee.USERNAME}, ${Employee.NAME})
+      |VALUES (?, ?)
+      |""".trimMargin(), INSERT)
+    statement.bindString(1, employee.username)
+    statement.bindString(2, employee.name)
+    val result = statement.execute()
+    notify(TABLE_EMPLOYEE)
+    return result
+  }
+
+  fun manager(
+    employeeId: Long,
+    managerId: Long
+  ): Long {
+    val statement = db.prepareStatement("""
+      |INSERT OR FAIL INTO $TABLE_MANAGER (${Manager.EMPLOYEE_ID}, ${Manager.MANAGER_ID})
+      |VALUES (?, ?)
+      |""".trimMargin(), INSERT)
+    statement.bindLong(1, employeeId)
+    statement.bindLong(2, managerId)
+    val result = statement.execute()
+    notify(TABLE_MANAGER)
+    return result
+  }
+
+  companion object {
+    const val TABLE_EMPLOYEE = "employee"
+    const val TABLE_MANAGER = "manager"
+
+    val CREATE_EMPLOYEE = """
+      |CREATE TABLE $TABLE_EMPLOYEE (
+      |  ${Employee.ID} INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      |  ${Employee.USERNAME} TEXT NOT NULL UNIQUE,
+      |  ${Employee.NAME} TEXT NOT NULL
+      |)
+    """.trimMargin()
+
+    val CREATE_MANAGER = """
+      |CREATE TABLE $TABLE_MANAGER (
+      |  ${Manager.ID} INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      |  ${Manager.EMPLOYEE_ID} INTEGER NOT NULL UNIQUE REFERENCES $TABLE_EMPLOYEE(${Employee.ID}),
+      |  ${Manager.MANAGER_ID} INTEGER NOT NULL REFERENCES $TABLE_EMPLOYEE(${Employee.ID})
+      |)
+    """.trimMargin()
+  }
+}
+
+object Manager {
+  const val ID = "id"
+  const val EMPLOYEE_ID = "employee_id"
+  const val MANAGER_ID = "manager_id"
+
+  val SELECT_MANAGER_LIST = """
+    |SELECT e.${Employee.NAME}, m.${Employee.NAME}
+    |FROM $TABLE_MANAGER AS manager
+    |JOIN $TABLE_EMPLOYEE AS e
+    |ON manager.$EMPLOYEE_ID = e.${Employee.ID}
+    |JOIN $TABLE_EMPLOYEE AS m
+    |ON manager.$MANAGER_ID = m.${Employee.ID}
+    |""".trimMargin()
+}
+
+data class Employee(val username: String, val name: String) {
+  companion object {
+    const val ID = "id"
+    const val USERNAME = "username"
+    const val NAME = "name"
+
+    const val SELECT_EMPLOYEES = "SELECT $USERNAME, $NAME FROM $TABLE_EMPLOYEE"
+
+    val MAPPER = { resultSet: SqlResultSet ->
+      Employee(resultSet.getString(0)!!, resultSet.getString(1)!!)
+    }
+  }
+}

--- a/runtime/sqldelight-runtime/build.gradle
+++ b/runtime/sqldelight-runtime/build.gradle
@@ -5,7 +5,6 @@ dependencies {
   implementation deps.kotlin.stdlib
 
   testImplementation deps.junit
-  testImplementation deps.okio
   testImplementation deps.truth
   testImplementation project(':runtime:sqlite-driver')
 }

--- a/runtime/sqldelight-runtime/src/main/java/com/squareup/sqldelight/Query.kt
+++ b/runtime/sqldelight-runtime/src/main/java/com/squareup/sqldelight/Query.kt
@@ -24,7 +24,7 @@ import com.squareup.sqldelight.db.use
  *
  * @param RowType the type that this query can map it's result set to.
  */
-open class Query<out RowType>(
+open class Query<out RowType : Any>(
   private val statement: SqlPreparedStatement,
   private val queryQueue: MutableList<Query<*>>,
   private val mapper: (SqlResultSet) -> RowType

--- a/runtime/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/SqliteJdbcOpenHelper.kt
+++ b/runtime/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/SqliteJdbcOpenHelper.kt
@@ -11,8 +11,8 @@ import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Types
 
-class SqliteJdbcOpenHelper : SqlDatabase {
-  private val connection = SqliteJdbcConnection(DriverManager.getConnection("jdbc:sqlite:"))
+class SqliteJdbcOpenHelper(name: String = "jdbc:sqlite:") : SqlDatabase {
+  private val connection = SqliteJdbcConnection(DriverManager.getConnection(name))
 
   override fun getConnection(): SqlDatabaseConnection = connection
   override fun close() = connection.close()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'sqldelight'
 
 include ':runtime:android-driver'
+include ':runtime:rxjava2-extensions'
 include ':runtime:sqldelight-runtime'
 include ':runtime:sqlite-driver'
 include ':sqldelight-core'

--- a/sqldelight-core-integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-core-integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -6,6 +6,7 @@ import com.squareup.sqldelight.core.integration.Shoots
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlPreparedStatement
 import com.squareup.sqldelight.db.SqlResultSet
+import kotlin.Any
 import kotlin.Boolean
 import kotlin.Long
 import kotlin.String
@@ -26,7 +27,7 @@ class PlayerQueries(private val queryWrapper: QueryWrapper, private val database
             """.trimMargin(), SqlPreparedStatement.Type.INSERT))
             }
 
-    fun <T> allPlayers(mapper: (
+    fun <T : Any> allPlayers(mapper: (
             name: String,
             number: Long,
             team: String?,
@@ -48,7 +49,7 @@ class PlayerQueries(private val queryWrapper: QueryWrapper, private val database
 
     fun allPlayers(): Query<Player> = allPlayers(Player::Impl)
 
-    fun <T> playersForTeam(team: String?, mapper: (
+    fun <T : Any> playersForTeam(team: String?, mapper: (
             name: String,
             number: Long,
             team: String?,
@@ -72,7 +73,7 @@ class PlayerQueries(private val queryWrapper: QueryWrapper, private val database
 
     fun playersForTeam(team: String?): Query<Player> = playersForTeam(team, Player::Impl)
 
-    fun <T> playersForNumbers(number: Collection<Long>, mapper: (
+    fun <T : Any> playersForNumbers(number: Collection<Long>, mapper: (
             name: String,
             number: Long,
             team: String?,
@@ -124,7 +125,7 @@ class PlayerQueries(private val queryWrapper: QueryWrapper, private val database
         return statement.execute()
     }
 
-    private inner class PlayersForTeam<out T>(
+    private inner class PlayersForTeam<out T : Any>(
             private val team: String?,
             statement: SqlPreparedStatement,
             mapper: (SqlResultSet) -> T
@@ -132,7 +133,7 @@ class PlayerQueries(private val queryWrapper: QueryWrapper, private val database
         fun dirtied(team: String?): Boolean = true
     }
 
-    private inner class PlayersForNumbers<out T>(
+    private inner class PlayersForNumbers<out T : Any>(
             private val number: Collection<Long>,
             statement: SqlPreparedStatement,
             mapper: (SqlResultSet) -> T

--- a/sqldelight-core-integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-core-integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -5,6 +5,7 @@ import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlPreparedStatement
 import com.squareup.sqldelight.db.SqlResultSet
+import kotlin.Any
 import kotlin.Boolean
 import kotlin.Long
 import kotlin.String
@@ -13,7 +14,7 @@ import kotlin.collections.MutableList
 class TeamQueries(private val queryWrapper: QueryWrapper, private val database: SqlDatabase) : Transacter(database) {
     internal val teamForCoach: MutableList<Query<*>> = mutableListOf()
 
-    fun <T> teamForCoach(coach: String, mapper: (
+    fun <T : Any> teamForCoach(coach: String, mapper: (
             name: String,
             captain: Long,
             coach: String
@@ -35,7 +36,7 @@ class TeamQueries(private val queryWrapper: QueryWrapper, private val database: 
 
     fun teamForCoach(coach: String): Query<Team> = teamForCoach(coach, Team::Impl)
 
-    private inner class TeamForCoach<out T>(
+    private inner class TeamForCoach<out T : Any>(
             private val coach: String,
             statement: SqlPreparedStatement,
             mapper: (SqlResultSet) -> T

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -92,7 +92,7 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
       // Function takes a custom mapper.
 
       // Add the type variable to the signature.
-      val typeVariable = TypeVariableName("T")
+      val typeVariable = TypeVariableName("T", ANY)
       function.addTypeVariable(typeVariable)
 
       // Add the custom mapper to the signature:
@@ -184,7 +184,7 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
 
     // The custom return type variable:
     // <out T>
-    val returnType = TypeVariableName("T", OUT)
+    val returnType = TypeVariableName("T", bounds = ANY, variance = OUT)
     queryType.addTypeVariable(returnType)
 
     // The superclass:

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -39,6 +39,7 @@ class QueriesTypeTest {
       |import com.squareup.sqldelight.db.SqlDatabase
       |import com.squareup.sqldelight.db.SqlPreparedStatement
       |import com.squareup.sqldelight.db.SqlResultSet
+      |import kotlin.Any
       |import kotlin.Boolean
       |import kotlin.Long
       |import kotlin.collections.List
@@ -54,7 +55,7 @@ class QueriesTypeTest {
       |            ""${'"'}.trimMargin(), SqlPreparedStatement.Type.INSERT))
       |            }
       |
-      |    fun <T> selectForId(id: Long, mapper: (id: Long, value: List?) -> T): Query<T> {
+      |    fun <T : Any> selectForId(id: Long, mapper: (id: Long, value: List?) -> T): Query<T> {
       |        val statement = database.getConnection().prepareStatement(""${'"'}
       |                |SELECT *
       |                |FROM data
@@ -73,7 +74,7 @@ class QueriesTypeTest {
       |
       |    fun insertData(id: Long?, value: List?): Long = insertData.execute(id, value)
       |
-      |    private inner class SelectForId<out T>(
+      |    private inner class SelectForId<out T : Any>(
       |            private val id: Long,
       |            statement: SqlPreparedStatement,
       |            mapper: (SqlResultSet) -> T

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -44,7 +44,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-    |fun <T> selectForId(id: kotlin.Long, mapper: (id: kotlin.Long, value: kotlin.String) -> T): com.squareup.sqldelight.Query<T> {
+    |fun <T : kotlin.Any> selectForId(id: kotlin.Long, mapper: (id: kotlin.Long, value: kotlin.String) -> T): com.squareup.sqldelight.Query<T> {
     |    val statement = database.getConnection().prepareStatement(""${'"'}
     |            |SELECT *
     |            |FROM data
@@ -79,7 +79,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |fun <T> selectForId(id: kotlin.Long, mapper: (id: kotlin.Long, value: kotlin.collections.List) -> T): com.squareup.sqldelight.Query<T> {
+      |fun <T : kotlin.Any> selectForId(id: kotlin.Long, mapper: (id: kotlin.Long, value: kotlin.collections.List) -> T): com.squareup.sqldelight.Query<T> {
       |    val statement = database.getConnection().prepareStatement(""${'"'}
       |            |SELECT *
       |            |FROM data
@@ -125,7 +125,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |fun <T> selectForId(mapper: (id: kotlin.Long, value: kotlin.collections.List) -> T): com.squareup.sqldelight.Query<T> {
+      |fun <T : kotlin.Any> selectForId(mapper: (id: kotlin.Long, value: kotlin.collections.List) -> T): com.squareup.sqldelight.Query<T> {
       |    val statement = database.getConnection().prepareStatement(""${'"'}
       |            |SELECT *
       |            |FROM data
@@ -245,7 +245,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |fun <T> selectData(mapper: (id: kotlin.Long, value: kotlin.Boolean?) -> T): com.squareup.sqldelight.Query<T> {
+      |fun <T : kotlin.Any> selectData(mapper: (id: kotlin.Long, value: kotlin.Boolean?) -> T): com.squareup.sqldelight.Query<T> {
       |    val statement = database.getConnection().prepareStatement(""${'"'}
       |            |SELECT *
       |            |FROM data
@@ -278,7 +278,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |fun <T> equivalentNamesNamed(name: kotlin.String, mapper: (
+      |fun <T : kotlin.Any> equivalentNamesNamed(name: kotlin.String, mapper: (
       |        _id: kotlin.Long,
       |        first_name: kotlin.String,
       |        last_name: kotlin.String

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -25,7 +25,7 @@ class SelectQueryTypeTest {
     val generator = SelectQueryGenerator(file.namedQueries.first())
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
-      |private inner class SelectForId<out T>(
+      |private inner class SelectForId<out T : kotlin.Any>(
       |        private val id: kotlin.Long,
       |        statement: com.squareup.sqldelight.db.SqlPreparedStatement,
       |        mapper: (com.squareup.sqldelight.db.SqlResultSet) -> T
@@ -50,7 +50,7 @@ class SelectQueryTypeTest {
     val generator = SelectQueryGenerator(file.namedQueries.first())
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
-      |private inner class SelectForId<out T>(
+      |private inner class SelectForId<out T : kotlin.Any>(
       |        private val id: kotlin.collections.Collection<kotlin.Long>,
       |        statement: com.squareup.sqldelight.db.SqlPreparedStatement,
       |        mapper: (com.squareup.sqldelight.db.SqlResultSet) -> T


### PR DESCRIPTION
Not sure if what I did for scheduling is actually the best api. Should the extension method not apply any scheduling? In my head its similar to the operations that emit after some amount of time (like `throttle`) which all default to something (`computation`) in that case.

But, there is no upstream from `observe()`. Does it make sense to just use the scheduler supplied as a `subscribeOn` to perform the actual query in every case? I can get that via `RxJavaPlugins.getScheduleHandler()` during `subscribeActual` and if its null I just emit on the same thread the notification was received on. That's not really obvious behavior though where the explicit scheduler argument is, which is why I went with this. 