### PR TITLE
Move ownership of transaction creation to drivers

### DIFF
--- a/runtime/android-driver/src/test/java/com/squareup/sqldelight/android/TransacterTest.kt
+++ b/runtime/android-driver/src/test/java/com/squareup/sqldelight/android/TransacterTest.kt
@@ -1,23 +1,34 @@
-package com.squareup.sqldelight
+package com.squareup.sqldelight.android
 
+import android.arch.persistence.db.SupportSQLiteDatabase
+import android.arch.persistence.db.SupportSQLiteOpenHelper
+import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory
 import com.google.common.truth.Truth.assertThat
+import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.db.SqlDatabaseConnection
-import com.squareup.sqldelight.sqlite.driver.SqliteJdbcOpenHelper
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
-import java.util.concurrent.atomic.AtomicInteger
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 
+@RunWith(RobolectricTestRunner::class)
 class TransacterTest {
   private lateinit var transacter: Transacter
-  private lateinit var connection: SqlDatabaseConnection
-  private lateinit var databaseHelper: SqliteJdbcOpenHelper
+  private lateinit var databaseHelper: SqlDelightDatabaseHelper
 
   @Before fun setup() {
-    databaseHelper = SqliteJdbcOpenHelper()
+    val configuration = SupportSQLiteOpenHelper.Configuration.builder(RuntimeEnvironment.application)
+        .callback(object : SupportSQLiteOpenHelper.Callback(1) {
+      override fun onCreate(db: SupportSQLiteDatabase) {}
+      override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {}
+    }).build()
+    val openHelper = FrameworkSQLiteOpenHelperFactory().create(configuration)
+    databaseHelper = SqlDelightDatabaseHelper(openHelper)
     transacter = object : Transacter(databaseHelper) {}
-    connection = databaseHelper.getConnection()
   }
 
   @After fun teardown() {

--- a/runtime/sqldelight-runtime/src/main/java/com/squareup/sqldelight/db/SqlDatabaseConnection.kt
+++ b/runtime/sqldelight-runtime/src/main/java/com/squareup/sqldelight/db/SqlDatabaseConnection.kt
@@ -15,9 +15,18 @@
  */
 package com.squareup.sqldelight.db
 
+import com.squareup.sqldelight.Transacter
+
 interface SqlDatabaseConnection {
   fun prepareStatement(sql: String, type: SqlPreparedStatement.Type): SqlPreparedStatement
-  fun beginTransaction()
-  fun commitTransaction()
-  fun rollbackTransaction()
+
+  /**
+   * Start a new [Transacter.Transaction] for this connection.
+   */
+  fun newTransaction(): Transacter.Transaction
+
+  /**
+   * The currently open [Transacter.Transaction] for this connection.
+   */
+  fun currentTransaction(): Transacter.Transaction?
 }

--- a/sqldelight-core-integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-core-integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -6,18 +6,13 @@ import com.squareup.sqldelight.core.integration.Shoots
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlPreparedStatement
 import com.squareup.sqldelight.db.SqlResultSet
-import java.lang.ThreadLocal
 import kotlin.Boolean
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.Collection
 import kotlin.collections.MutableList
 
-class PlayerQueries(
-        private val queryWrapper: QueryWrapper,
-        private val database: SqlDatabase,
-        transactions: ThreadLocal<Transacter.Transaction>
-) : Transacter(database, transactions) {
+class PlayerQueries(private val queryWrapper: QueryWrapper, private val database: SqlDatabase) : Transacter(database) {
     internal val allPlayers: MutableList<Query<*>> = mutableListOf()
 
     internal val playersForTeam: MutableList<Query<*>> = mutableListOf()

--- a/sqldelight-core-integration-tests/src/test/kotlin/com/example/QueryWrapper.kt
+++ b/sqldelight-core-integration-tests/src/test/kotlin/com/example/QueryWrapper.kt
@@ -1,19 +1,14 @@
 package com.example
 
-import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlDatabaseConnection
 import com.squareup.sqldelight.db.SqlPreparedStatement
-import java.lang.ThreadLocal
 import kotlin.Int
 
 class QueryWrapper(database: SqlDatabase, internal val playerAdapter: Player.Adapter) {
-    private val transactions: ThreadLocal<Transacter.Transaction> =
-            ThreadLocal<Transacter.Transaction>()
+    val teamQueries: TeamQueries = TeamQueries(this, database)
 
-    val teamQueries: TeamQueries = TeamQueries(this, database, transactions)
-
-    val playerQueries: PlayerQueries = PlayerQueries(this, database, transactions)
+    val playerQueries: PlayerQueries = PlayerQueries(this, database)
     companion object : SqlDatabase.Helper {
         override fun onCreate(db: SqlDatabaseConnection) {
             db.prepareStatement("""

--- a/sqldelight-core-integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-core-integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -5,17 +5,12 @@ import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlPreparedStatement
 import com.squareup.sqldelight.db.SqlResultSet
-import java.lang.ThreadLocal
 import kotlin.Boolean
 import kotlin.Long
 import kotlin.String
 import kotlin.collections.MutableList
 
-class TeamQueries(
-        private val queryWrapper: QueryWrapper,
-        private val database: SqlDatabase,
-        transactions: ThreadLocal<Transacter.Transaction>
-) : Transacter(database, transactions) {
+class TeamQueries(private val queryWrapper: QueryWrapper, private val database: SqlDatabase) : Transacter(database) {
     internal val teamForCoach: MutableList<Query<*>> = mutableListOf()
 
     fun <T> teamForCoach(coach: String, mapper: (

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueriesTypeGenerator.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueriesTypeGenerator.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.module.Module
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.sqldelight.core.SqlDelightFileIndex
@@ -12,10 +11,7 @@ import com.squareup.sqldelight.core.lang.DATABASE_NAME
 import com.squareup.sqldelight.core.lang.DATABASE_TYPE
 import com.squareup.sqldelight.core.lang.QUERY_WRAPPER_NAME
 import com.squareup.sqldelight.core.lang.SqlDelightFile
-import com.squareup.sqldelight.core.lang.THREADLOCAL_TYPE
 import com.squareup.sqldelight.core.lang.TRANSACTER_TYPE
-import com.squareup.sqldelight.core.lang.TRANSACTIONS_NAME
-import com.squareup.sqldelight.core.lang.TRANSACTION_TYPE
 import com.squareup.sqldelight.core.lang.queriesName
 import com.squareup.sqldelight.core.lang.util.isArrayParameter
 
@@ -58,14 +54,6 @@ class QueriesTypeGenerator(
         .build())
     constructor.addParameter(DATABASE_NAME, DATABASE_TYPE)
     type.addSuperclassConstructorParameter(DATABASE_NAME)
-
-    // ADd the transactions as a constructor parameter and superclass parameter:
-    // transactions: ThreadLocal<Transacter.Transaction>
-    constructor.addParameter(TRANSACTIONS_NAME, ParameterizedTypeName.get(
-        rawType = THREADLOCAL_TYPE,
-        typeArguments = TRANSACTION_TYPE
-    ))
-    type.addSuperclassConstructorParameter(TRANSACTIONS_NAME)
 
     file.namedQueries.forEach { query ->
       tryWithElement(query.select) {

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryWrapperGenerator.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryWrapperGenerator.kt
@@ -22,9 +22,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
-import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.sqldelight.core.SqlDelightFileIndex
@@ -38,9 +36,6 @@ import com.squareup.sqldelight.core.lang.DATABASE_TYPE
 import com.squareup.sqldelight.core.lang.QUERY_WRAPPER_NAME
 import com.squareup.sqldelight.core.lang.STATEMENT_TYPE_ENUM
 import com.squareup.sqldelight.core.lang.SqlDelightFile
-import com.squareup.sqldelight.core.lang.THREADLOCAL_TYPE
-import com.squareup.sqldelight.core.lang.TRANSACTIONS_NAME
-import com.squareup.sqldelight.core.lang.TRANSACTION_TYPE
 import com.squareup.sqldelight.core.lang.adapterName
 import com.squareup.sqldelight.core.lang.queriesName
 import com.squareup.sqldelight.core.lang.queriesType
@@ -61,16 +56,6 @@ internal class QueryWrapperGenerator(module: Module) {
     val dbParameter = ParameterSpec.builder(DATABASE_NAME, DATABASE_TYPE).build()
     constructor.addParameter(dbParameter)
 
-    // transactions property:
-    // private val transactions = ThreadLocal<Transacter.Transaction>()
-    val transactionsType = ParameterizedTypeName.get(
-        rawType = THREADLOCAL_TYPE,
-        typeArguments = TRANSACTION_TYPE
-    )
-    typeSpec.addProperty(PropertySpec.builder(TRANSACTIONS_NAME, transactionsType, PRIVATE)
-        .initializer("%T()", transactionsType)
-        .build())
-
     // Static on create function:
     // fun onCreate(db: SqlDatabaseConnection)
     val onCreateFunction = FunSpec.builder("onCreate")
@@ -88,7 +73,7 @@ internal class QueryWrapperGenerator(module: Module) {
           // queries property added to QueryWrapper type:
           // val dataQueries = DataQueries(this, database, transactions)
           typeSpec.addProperty(PropertySpec.builder(file.queriesName, file.queriesType)
-              .initializer("%T(this, $DATABASE_NAME, $TRANSACTIONS_NAME)", file.queriesType)
+              .initializer("%T(this, $DATABASE_NAME)", file.queriesType)
               .build())
 
           file.sqliteStatements().forEach statements@{ (label, sqliteStatement) ->

--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
@@ -2,7 +2,6 @@ package com.squareup.sqldelight.core.lang
 
 import com.alecstrong.sqlite.psi.core.psi.SqliteCreateTableStmt
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.asClassName
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
 
 internal val RESULT_SET_TYPE = ClassName("com.squareup.sqldelight.db", "SqlResultSet")
@@ -39,10 +38,6 @@ internal val SqlDelightFile.queriesType
 
 internal val TRANSACTER_TYPE = ClassName("com.squareup.sqldelight", "Transacter")
 internal val TRANSACTION_TYPE = TRANSACTER_TYPE.nestedClass("Transaction")
-internal val TRANSACTIONS_NAME = "transactions"
-
-// TODO: Oh fuck threadlocal is a java type. Ill think about this later
-internal val THREADLOCAL_TYPE = ThreadLocal::class.asClassName()
 
 internal val CONNECTION_TYPE = ClassName("com.squareup.sqldelight.db", "SqlDatabaseConnection")
 internal val CONNECTION_NAME = "db"

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -39,17 +39,12 @@ class QueriesTypeTest {
       |import com.squareup.sqldelight.db.SqlDatabase
       |import com.squareup.sqldelight.db.SqlPreparedStatement
       |import com.squareup.sqldelight.db.SqlResultSet
-      |import java.lang.ThreadLocal
       |import kotlin.Boolean
       |import kotlin.Long
       |import kotlin.collections.List
       |import kotlin.collections.MutableList
       |
-      |class DataQueries(
-      |        private val queryWrapper: QueryWrapper,
-      |        private val database: SqlDatabase,
-      |        transactions: ThreadLocal<Transacter.Transaction>
-      |) : Transacter(database, transactions) {
+      |class DataQueries(private val queryWrapper: QueryWrapper, private val database: SqlDatabase) : Transacter(database) {
       |    internal val selectForId: MutableList<Query<*>> = mutableListOf()
       |
       |    private val insertData: InsertData by lazy {

--- a/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-core/src/test/kotlin/com/squareup/sqldelight/core/QueryWrapperTest.kt
@@ -28,18 +28,13 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo("""
       |package com.example
       |
-      |import com.squareup.sqldelight.Transacter
       |import com.squareup.sqldelight.db.SqlDatabase
       |import com.squareup.sqldelight.db.SqlDatabaseConnection
       |import com.squareup.sqldelight.db.SqlPreparedStatement
-      |import java.lang.ThreadLocal
       |import kotlin.Int
       |
       |class QueryWrapper(database: SqlDatabase) {
-      |    private val transactions: ThreadLocal<Transacter.Transaction> =
-      |            ThreadLocal<Transacter.Transaction>()
-      |
-      |    val testQueries: TestQueries = TestQueries(this, database, transactions)
+      |    val testQueries: TestQueries = TestQueries(this, database)
       |    companion object : SqlDatabase.Helper {
       |        override fun onCreate(db: SqlDatabaseConnection) {
       |            db.prepareStatement(""${'"'}
@@ -87,11 +82,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo("""
         |package com.example
         |
-        |import com.squareup.sqldelight.Transacter
         |import com.squareup.sqldelight.db.SqlDatabase
         |import com.squareup.sqldelight.db.SqlDatabaseConnection
         |import com.squareup.sqldelight.db.SqlPreparedStatement
-        |import java.lang.ThreadLocal
         |import kotlin.Int
         |
         |class QueryWrapper(
@@ -99,10 +92,7 @@ class QueryWrapperTest {
         |        internal val test_tableAdapter: Test_table.Adapter,
         |        internal val test_table2Adapter: Test_table2.Adapter
         |) {
-        |    private val transactions: ThreadLocal<Transacter.Transaction> =
-        |            ThreadLocal<Transacter.Transaction>()
-        |
-        |    val testQueries: TestQueries = TestQueries(this, database, transactions)
+        |    val testQueries: TestQueries = TestQueries(this, database)
         |    companion object : SqlDatabase.Helper {
         |        override fun onCreate(db: SqlDatabaseConnection) {
         |            db.prepareStatement(""${'"'}


### PR DESCRIPTION
cc @swankjesse 

Puts the burden of maintaining transactions on the database connection. SQLite and Android drivers do super basic single-connection multiple-thread implementations.