### PR TITLE
Update Android DB abstraction to 1.1.0.

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
     compileSdk: 27,
     idea: '2018.1',
     dokka: '0.9.15',
-    archDb: '1.0.0',
+    archDb: '1.1.0',
     minSdk: 14,
     autoValue: '1.5.4',
     autoValueAnnotations: '1.5',

--- a/runtime/android-driver/src/main/java/com/squareup/sqldelight/android/SqlDelightDatabaseHelper.kt
+++ b/runtime/android-driver/src/main/java/com/squareup/sqldelight/android/SqlDelightDatabaseHelper.kt
@@ -196,6 +196,10 @@ private class SqlDelightQuery(
   override fun getSql() = sql
 
   override fun toString() = sql
+
+  override fun getArgCount(): Int {
+    throw UnsupportedOperationException("Not implemented")
+  }
 }
 
 private class SqlDelightResultSet(


### PR DESCRIPTION
This brings a new argument count method which we do not yet support.