### PR TITLE
Update Android Gradle Plugin to 3.2.0-alpha18

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext.versions = [
 
 ext.deps = [
     plugins: [
-        android: 'com.android.tools.build:gradle:3.2.0-alpha16',
+        android: 'com.android.tools.build:gradle:3.2.0-alpha18',
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
         download: "de.undercouch:gradle-download-task:3.4.2",


### PR DESCRIPTION
Could not verify this locally though since I'm getting:

```
* What went wrong:
A problem occurred configuring project ':sqldelight-idea-plugin'.
> Failed to notify project evaluation listener.
   > org/gradle/api/publish/ivy/internal/artifact/DefaultIvyArtifact
   > org/gradle/api/publish/ivy/internal/artifact/DefaultIvyArtifact
   > org/gradle/api/publish/ivy/internal/artifact/DefaultIvyArtifact
   > org/gradle/api/publish/ivy/internal/artifact/DefaultIvyArtifact
```