### PR TITLE
Support nullable values in android-driver's SqlDelightResultSet

### DIFF
--- a/runtime/android-driver/src/main/java/com/squareup/sqldelight/android/SqlDelightDatabaseHelper.kt
+++ b/runtime/android-driver/src/main/java/com/squareup/sqldelight/android/SqlDelightDatabaseHelper.kt
@@ -209,9 +209,9 @@ private class SqlDelightResultSet(
   private val cursor: Cursor
 ) : SqlResultSet {
   override fun next() = cursor.moveToNext()
-  override fun getString(index: Int) = cursor.getString(index)
-  override fun getLong(index: Int) = cursor.getLong(index)
-  override fun getBytes(index: Int) = cursor.getBlob(index)
-  override fun getDouble(index: Int) = cursor.getDouble(index)
+  override fun getString(index: Int) = if (cursor.isNull(index)) null else cursor.getString(index)
+  override fun getLong(index: Int) = if (cursor.isNull(index)) null else cursor.getLong(index)
+  override fun getBytes(index: Int) = if (cursor.isNull(index)) null else cursor.getBlob(index)
+  override fun getDouble(index: Int) = if (cursor.isNull(index)) null else cursor.getDouble(index)
   override fun close() = cursor.close()
 }


### PR DESCRIPTION
Current `SqlResultSet.getLong(index: Int)` and `SqlResultSet.getDouble(index: Int)` implementation in `android-driver` returns `0` and `0.0` respectively if the value in the column is `NULL`.

This change adds a check for `NULL` for all getters.