### PR TITLE
Migrate to AndroidX

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
     compileSdk: 28,
     idea: '2018.1',
     dokka: '0.9.15',
-    archDb: '1.1.0',
+    androidxSqlite: '2.0.0-rc01',
     minSdk: 14,
     autoValue: '1.6.2',
     schemaCrawler: '14.16.04.01-java7',
@@ -31,9 +31,9 @@ ext.deps = [
         testCommonAnnotations: "org.jetbrains.kotlin:kotlin-test-annotations-common:${versions.kotlin}",
         testJs: "org.jetbrains.kotlin:kotlin-test-js:${versions.kotlin}",
     ],
-    arch: [
-        db: "android.arch.persistence:db:${versions.archDb}",
-        dbFramework: "android.arch.persistence:db-framework:${versions.archDb}",
+    androidx: [
+        sqlite: "androidx.sqlite:sqlite:${versions.androidxSqlite}",
+        sqliteFramework: "androidx.sqlite:sqlite-framework:${versions.androidxSqlite}",
     ],
     support: [
         test: [

--- a/runtime/android-driver/build.gradle
+++ b/runtime/android-driver/build.gradle
@@ -40,15 +40,14 @@ android {
 
 dependencies {
   implementation deps.kotlin.stdlib
-  implementation deps.arch.dbFramework
+  implementation deps.androidx.sqliteFramework
 
   api project(':runtime:sqldelight-runtime:jdk')
-  api deps.arch.db
+  api deps.androidx.sqlite
 
   testImplementation deps.junit
   testImplementation deps.truth
   testImplementation deps.robolectric
-  testImplementation deps.arch.dbFramework
 }
 
 configurations {

--- a/runtime/android-driver/src/main/java/com/squareup/sqldelight/android/SqlDelightDatabaseHelper.kt
+++ b/runtime/android-driver/src/main/java/com/squareup/sqldelight/android/SqlDelightDatabaseHelper.kt
@@ -1,14 +1,14 @@
 @file:JvmName("SqlDelight")
 package com.squareup.sqldelight.android
 
-import android.arch.persistence.db.SupportSQLiteDatabase
-import android.arch.persistence.db.SupportSQLiteOpenHelper
-import android.arch.persistence.db.SupportSQLiteProgram
-import android.arch.persistence.db.SupportSQLiteQuery
-import android.arch.persistence.db.SupportSQLiteStatement
-import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory
 import android.content.Context
 import android.database.Cursor
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.SupportSQLiteProgram
+import androidx.sqlite.db.SupportSQLiteQuery
+import androidx.sqlite.db.SupportSQLiteStatement
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlDatabaseConnection

--- a/runtime/android-driver/src/test/java/com/squareup/sqldelight/android/DriverTest.kt
+++ b/runtime/android-driver/src/test/java/com/squareup/sqldelight/android/DriverTest.kt
@@ -1,8 +1,8 @@
 package com.squareup.sqldelight.android
 
-import android.arch.persistence.db.SupportSQLiteDatabase
-import android.arch.persistence.db.SupportSQLiteOpenHelper
-import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE

--- a/runtime/android-driver/src/test/java/com/squareup/sqldelight/android/TransacterTest.kt
+++ b/runtime/android-driver/src/test/java/com/squareup/sqldelight/android/TransacterTest.kt
@@ -1,11 +1,10 @@
 package com.squareup.sqldelight.android
 
-import android.arch.persistence.db.SupportSQLiteDatabase
-import android.arch.persistence.db.SupportSQLiteOpenHelper
-import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.Transacter
-import com.squareup.sqldelight.db.SqlDatabaseConnection
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.After
 import org.junit.Before

--- a/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
@@ -29,8 +29,8 @@ repositories {
 dependencies {
   implementation deps.kotlin.stdlib
 
-  implementation deps.arch.db
-  implementation deps.arch.dbFramework
+  implementation deps.androidx.sqlite
+  implementation deps.androidx.sqliteFramework
 
   // TODO why don't these work when specified as androidTestImplementation?
   compile deps.support.test.runner

--- a/sqldelight-gradle-plugin/src/test/integration-android/src/androidTest/java/com/squareup/sqldelight/integration/IntegrationTests.java
+++ b/sqldelight-gradle-plugin/src/test/integration-android/src/androidTest/java/com/squareup/sqldelight/integration/IntegrationTests.java
@@ -1,8 +1,8 @@
 package com.squareup.sqldelight.integration;
 
-import android.arch.persistence.db.SupportSQLiteOpenHelper;
-import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory;
 import android.support.test.InstrumentationRegistry;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import com.squareup.sqldelight.android.SqlDelightDatabaseHelper;
 import com.squareup.sqldelight.android.SqlDelight;
 import com.squareup.sqldelight.db.SqlDatabase;

--- a/sqldelight-gradle-plugin/src/test/integration-android/src/androidTest/java/com/squareup/sqldelight/integration/MigrationTest.java
+++ b/sqldelight-gradle-plugin/src/test/integration-android/src/androidTest/java/com/squareup/sqldelight/integration/MigrationTest.java
@@ -1,9 +1,9 @@
 package com.squareup.sqldelight.integration;
 
-import android.arch.persistence.db.SupportSQLiteOpenHelper;
-import android.arch.persistence.db.SupportSQLiteDatabase;
-import android.arch.persistence.db.framework.FrameworkSQLiteOpenHelperFactory;
 import android.support.test.InstrumentationRegistry;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import com.squareup.sqldelight.android.SqlDelightDatabaseHelper;
 import com.squareup.sqldelight.android.SqlDelight;
 import com.squareup.sqldelight.db.SqlDatabase;

--- a/sqldelight-sample/build.gradle
+++ b/sqldelight-sample/build.gradle
@@ -65,7 +65,8 @@ repositories {
 
 dependencies {
   implementation deps.kotlin.stdlib
-  implementation deps.arch.dbFramework
+  // TODO implementation deps.androidx.sqliteFramework
+  implementation 'android.arch.persistence:db-framework:1.1.0'
 
   implementation "com.android.support:recyclerview-v7:${versions.support}"
   implementation "com.squareup.sqldelight:android-driver:${versions.sqldelight}"


### PR DESCRIPTION
Users who have not migrated can use dejetifier for compatibilit with android.arch.persistence.