### PR TITLE
Use the same result type if unioned columns have the same getter

### DIFF
--- a/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-core/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
@@ -156,7 +156,9 @@ data class NamedQuery(
       return IntermediateType(sqliteType = type, name = typeOne.name).nullableIf(nullable)
     }
 
-    if (typeOne.column !== typeTwo.column && typeOne.column != null && typeTwo.column != null) {
+    if (typeOne.column !== typeTwo.column &&
+        typeOne.resultSetGetter(0) != typeTwo.resultSetGetter(0) &&
+        typeOne.column != null && typeTwo.column != null) {
       // Incompatible adapters. Revert to unadapted java type.
       return IntermediateType(sqliteType = typeOne.sqliteType, name = typeOne.name).nullableIf(nullable)
     }


### PR DESCRIPTION
Closes #954 