### PR TITLE
Get rid of static installation of SDK components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: android
 
-android:
-  components:
-    - tools
-    - platform-tools
-    - android-27
-
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
AGP can take care of installing the things it needs itself.