### PR TITLE
Leverage task configuration avoidance.

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
@@ -31,14 +31,12 @@ open class GenerateSchemaTask : SourceTask() {
       maxVersion = maxOf(maxVersion, migrationFile.version + 1)
     }
 
-    val connection = DriverManager.getConnection("jdbc:sqlite:$outputDirectory/$maxVersion.db")
-
-    val sourceFiles = ArrayList<SqlDelightFile>()
-    environment.forSourceFiles { file -> sourceFiles.add(file as SqlDelightFile) }
-    sourceFiles.forInitializationStatements { sqlText ->
-      connection.prepareStatement(sqlText).execute()
+    DriverManager.getConnection("jdbc:sqlite:$outputDirectory/$maxVersion.db").use { connection ->
+      val sourceFiles = ArrayList<SqlDelightFile>()
+      environment.forSourceFiles { file -> sourceFiles.add(file as SqlDelightFile) }
+      sourceFiles.forInitializationStatements { sqlText ->
+        connection.prepareStatement(sqlText).execute()
+      }
     }
-
-    connection.close()
   }
 }


### PR DESCRIPTION
This uses task configuration avoidaance for all tasks created by the
SqlDelightPlugin except the generateSqlDelightInterface task. It must be
configured in order to be passed in to `registerJavaGeneratingTask`.

Fixes #927