### PR TITLE
Move downloading intellij outside configuration.

### DIFF
--- a/gradle/updateDependencies.gradle
+++ b/gradle/updateDependencies.gradle
@@ -19,9 +19,3 @@ task unzipIntellij(type: Copy) {
   into new File("lib/intellij-core")
   dependsOn(downloadIntellij)
 }
-
-// Make every other task depend on 'unzipIntellij'.
-// matching() and all() are "live" so any tasks declared after this line will also depend on 'unzipIntellij'
-tasks.matching { it.name != 'unzipIntellij' && it.name != 'downloadIntellij'}.all { Task task ->
-  task.dependsOn unzipIntellij
-}

--- a/gradle/updateDependencies.gradle
+++ b/gradle/updateDependencies.gradle
@@ -1,20 +1,27 @@
 apply plugin: 'de.undercouch.download'
 
-task updateDependencies {
-  def downloadDir = new File(project.rootDir, "lib/download")
-  downloadDir.mkdirs()
 
-  def intellijCoreZip = new File(downloadDir, "intellij-core-${versions.idea}.zip")
+// TODO This touches the filesystem during the gradle configuration phase. Move inside a task.
+def downloadDir = new File(project.rootDir, "lib/download")
+downloadDir.mkdirs()
 
-  download {
-    src "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/" +
-        "${versions.idea}/ideaIC-${versions.idea}.zip"
-    dest intellijCoreZip
-    onlyIfNewer true
-  }
+def intellijCoreZip = new File(downloadDir, "intellij-core-${versions.idea}.zip")
 
-  copy {
-    from zipTree(intellijCoreZip)
-    into new File("lib/intellij-core")
-  }
+task downloadIntellij(type: Download) {
+  src "https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/" +
+          "${versions.idea}/ideaIC-${versions.idea}.zip"
+  dest intellijCoreZip
+  onlyIfNewer true
+}
+
+task unzipIntellij(type: Copy) {
+  from zipTree(intellijCoreZip)
+  into new File("lib/intellij-core")
+  dependsOn(downloadIntellij)
+}
+
+// Make every other task depend on 'unzipIntellij'.
+// matching() and all() are "live" so any tasks declared after this line will also depend on 'unzipIntellij'
+tasks.matching { it.name != 'unzipIntellij' && it.name != 'downloadIntellij'}.all { Task task ->
+  task.dependsOn unzipIntellij
 }

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -65,5 +65,8 @@ task generateSqlDelightParser(type: GenerateParser) {
 
 tasks.getByName('compileKotlin').dependsOn('pluginVersion')
 tasks.getByName('compileKotlin').dependsOn('generateSqlDelightParser')
+tasks.named('generateSqlDelightParser').configure {
+  dependsOn(':unzipIntellij')
+}
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"


### PR DESCRIPTION
Downloading and unzipping of intellij were previously declared inside of
the body of a task instead of during the task action which meant that we
tried to download and unzip intellij whenever any gradle task was
executed.

This changes the download and unzip tasks to be separate tasks and
allows up to date checking to work properly. This reduces the
configuration time of the gradle build by about 15 seconds when the
files are already downloaded and unzipped.