### PR TITLE
Reopen #909: Fixes #784: Update arch db to 1.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ ext.versions = [
 
     sqldelight: '0.6.1',
     support: '27.0.2',
-    archDb: '1.0.0',
+    archDb: '1.1.1',
     kotlin: '1.0.6',
     antlr: '4.5.3',
     javaPoet: '1.10.0',

--- a/sqldelight-runtime/src/main/java/com/squareup/sqldelight/SqlDelightQuery.java
+++ b/sqldelight-runtime/src/main/java/com/squareup/sqldelight/SqlDelightQuery.java
@@ -24,4 +24,8 @@ public class SqlDelightQuery implements SupportSQLiteQuery {
 
   @Override public void bindTo(SupportSQLiteProgram statement) {
   }
+
+  @Override public int getArgCount() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/sqldelight-runtime/src/main/java/com/squareup/sqldelight/SqlDelightStatement.java
+++ b/sqldelight-runtime/src/main/java/com/squareup/sqldelight/SqlDelightStatement.java
@@ -19,6 +19,8 @@ import android.annotation.SuppressLint;
 import android.arch.persistence.db.SupportSQLiteStatement;
 import android.support.annotation.NonNull;
 
+import java.io.IOException;
+
 public abstract class SqlDelightStatement implements SupportSQLiteStatement {
   private final String table;
   private final SupportSQLiteStatement program;
@@ -79,7 +81,7 @@ public abstract class SqlDelightStatement implements SupportSQLiteStatement {
   }
 
   @SuppressLint("NewApi") // TODO Remove once 'db' version 1.1.0 is released and fixes this.
-  @Override public final void close() throws Exception {
+  @Override public final void close() throws IOException {
     program.close();
   }
 }

--- a/sqldelight-runtime/src/main/java/com/squareup/sqldelight/SqlDelightStatement.java
+++ b/sqldelight-runtime/src/main/java/com/squareup/sqldelight/SqlDelightStatement.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.sqldelight;
 
-import android.annotation.SuppressLint;
 import android.arch.persistence.db.SupportSQLiteStatement;
 import android.support.annotation.NonNull;
 
@@ -80,7 +79,6 @@ public abstract class SqlDelightStatement implements SupportSQLiteStatement {
     program.clearBindings();
   }
 
-  @SuppressLint("NewApi") // TODO Remove once 'db' version 1.1.0 is released and fixes this.
   @Override public final void close() throws IOException {
     program.close();
   }


### PR DESCRIPTION
throw an `UnsupportedOperationException` in `com.squareup.sqldelight.SqlDelightQuery#getArgCount` since it's unused by framework db.