### PR TITLE
Fix native implementation

### DIFF
--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 abstract class TransacterTest {
-  private lateinit var transacter: Transacter
+  protected lateinit var transacter: Transacter
   private lateinit var databaseHelper: SqlDatabase
 
   abstract fun setupDatabase(schema: Schema): SqlDatabase

--- a/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosTransacterTest.kt
+++ b/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosTransacterTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.native.concurrent.freeze
 
 class IosTransacterTest: TransacterTest() {
   override fun setupDatabase(schema: SqlDatabase.Schema): SqlDatabase {
@@ -25,6 +26,7 @@ class IosTransacterTest: TransacterTest() {
 
   @BeforeTest fun setup2() {
     super.setup()
+    transacter.freeze()
   }
 
   @AfterTest fun tearDown2() {

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -22,12 +22,7 @@ class PlayerQueries(private val queryWrapper: QueryWrapper, private val database
 
     internal val selectNull: QueryList = QueryList()
 
-    private val insertPlayer: InsertPlayer by lazy {
-            InsertPlayer(database.getConnection().prepareStatement("""
-            |INSERT INTO player
-            |VALUES (?, ?, ?, ?)
-            """.trimMargin(), SqlPreparedStatement.Type.INSERT, 4))
-            }
+    private val insertPlayer: InsertPlayer = InsertPlayer()
 
     fun <T : Any> allPlayers(mapper: (
         name: String,
@@ -139,7 +134,14 @@ class PlayerQueries(private val queryWrapper: QueryWrapper, private val database
         }
     }
 
-    private inner class InsertPlayer(private val statement: SqlPreparedStatement) {
+    private inner class InsertPlayer {
+        private val statement: SqlPreparedStatement by lazy {
+                database.getConnection().prepareStatement("""
+                |INSERT INTO player
+                |VALUES (?, ?, ?, ?)
+                """.trimMargin(), SqlPreparedStatement.Type.INSERT, 4)
+                }
+
         fun execute(
             name: String,
             number: Long,

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -47,12 +47,7 @@ class QueriesTypeTest {
       |class DataQueries(private val queryWrapper: QueryWrapper, private val database: SqlDatabase) : Transacter(database) {
       |    internal val selectForId: QueryList = QueryList()
       |
-      |    private val insertData: InsertData by lazy {
-      |            InsertData(database.getConnection().prepareStatement(""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?, ?)
-      |            ""${'"'}.trimMargin(), SqlPreparedStatement.Type.INSERT, 2))
-      |            }
+      |    private val insertData: InsertData = InsertData()
       |
       |    fun <T : Any> selectForId(id: Long, mapper: (id: Long, value: List?) -> T): Query<T> = SelectForId(id) { cursor ->
       |        mapper(
@@ -79,7 +74,14 @@ class QueriesTypeTest {
       |        }
       |    }
       |
-      |    private inner class InsertData(private val statement: SqlPreparedStatement) {
+      |    private inner class InsertData {
+      |        private val statement: SqlPreparedStatement by lazy {
+      |                database.getConnection().prepareStatement(""${'"'}
+      |                |INSERT INTO data
+      |                |VALUES (?, ?)
+      |                ""${'"'}.trimMargin(), SqlPreparedStatement.Type.INSERT, 2)
+      |                }
+      |
       |        fun execute(id: Long?, value: List?) {
       |            statement.bindLong(1, id)
       |            statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -45,13 +45,21 @@ class MutatorQueryFunctionTest {
 
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
-    assertThat(generator.value().toString()).isEqualTo("""
-      |private val insertData: InsertData by lazy {
-      |        InsertData(database.getConnection().prepareStatement(""${'"'}
-      |        |INSERT INTO data
-      |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2))
-      |        }
+    assertThat(generator.type().toString()).isEqualTo("""
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data
+      |            |VALUES (?, ?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
+      |            }
+      |
+      |    fun execute(id: kotlin.Long?, value: kotlin.collections.List?) {
+      |        statement.bindLong(1, id)
+      |        statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |        statement.execute()
+      |    }
+      |}
       |""".trimMargin())
   }
 
@@ -68,10 +76,16 @@ class MutatorQueryFunctionTest {
 
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
-    assertThat(generator.value().toString()).isEqualTo("""
-      |private val deleteData: DeleteData by lazy {
-      |        DeleteData(database.getConnection().prepareStatement("DELETE FROM data", com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE, 0))
-      |        }
+    assertThat(generator.type().toString()).isEqualTo("""
+      |private inner class DeleteData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement("DELETE FROM data", com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE, 0)
+      |            }
+      |
+      |    fun execute() {
+      |        statement.execute()
+      |    }
+      |}
       |""".trimMargin())
   }
 
@@ -89,13 +103,21 @@ class MutatorQueryFunctionTest {
 
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
-    assertThat(generator.value().toString()).isEqualTo("""
-      |private val insertData: InsertData by lazy {
-      |        InsertData(database.getConnection().prepareStatement(""${'"'}
-      |        |INSERT INTO data
-      |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2))
-      |        }
+    assertThat(generator.type().toString()).isEqualTo("""
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data
+      |            |VALUES (?, ?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
+      |            }
+      |
+      |    fun execute(id: kotlin.Long, value: kotlin.collections.List?) {
+      |        statement.bindLong(1, id)
+      |        statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |        statement.execute()
+      |    }
+      |}
       |""".trimMargin())
   }
 

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -25,7 +25,14 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data
+      |            |VALUES (?, ?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
+      |            }
+      |
       |    fun execute(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
       |        statement.bindLong(1, if (id == null) null else id.toLong())
       |        statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
@@ -55,7 +62,14 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data
+      |            |VALUES (?, ?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
+      |            }
+      |
       |    fun execute(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
       |        statement.bindLong(1, if (id == null) null else id.toLong())
       |        statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
@@ -88,7 +102,14 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data
+      |            |VALUES (?, ?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
+      |            }
+      |
       |    fun execute(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
       |        statement.bindLong(1, if (id == null) null else id.toLong())
       |        statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
@@ -130,7 +151,14 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data
+      |            |VALUES (?, ?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
+      |            }
+      |
       |    fun execute(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
       |        statement.bindLong(1, if (id == null) null else id.toLong())
       |        statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
@@ -155,7 +183,14 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data
+      |            |VALUES (?, ?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
+      |            }
+      |
       |    fun execute(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
       |        statement.bindLong(1, if (id == null) null else id.toLong())
       |        statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
@@ -191,7 +226,20 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class DeleteData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class DeleteData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |DELETE FROM data
+      |            |WHERE id = 1
+      |            |AND value IN (
+      |            |  SELECT data.value
+      |            |  FROM data
+      |            |  INNER JOIN data AS data2
+      |            |  ON data.id = data2.id
+      |            |)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE, 0)
+      |            }
+      |
       |    fun execute() {
       |        statement.execute()
       |        notifyQueries(queryWrapper.dataQueries.selectForId)
@@ -215,7 +263,14 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data (value)
+      |            |VALUES (?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
+      |            }
+      |
       |    fun execute(value: kotlin.Boolean) {
       |        statement.bindString(1, if (value) 1L else 0L)
       |        statement.execute()
@@ -239,7 +294,14 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data (value)
+      |            |VALUES (?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
+      |            }
+      |
       |    fun execute(value: kotlin.ByteArray) {
       |        statement.bindBytes(1, value)
       |        statement.execute()
@@ -263,7 +325,14 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data (value)
+      |            |VALUES (?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
+      |            }
+      |
       |    fun execute(value: kotlin.Double) {
       |        statement.bindDouble(1, value)
       |        statement.execute()
@@ -302,7 +371,11 @@ class MutatorQueryTypeTest {
     val generator = MutatorQueryGenerator(file.namedMutators.first())
 
     assertThat(generator.type().toString()).isEqualTo("""
-      |private inner class InsertItem(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertItem {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement("INSERT OR FAIL INTO item(packageName, className, deprecated, link) VALUES (?, ?, ?, ?)", com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 4)
+      |            }
+      |
       |    fun execute(
       |        packageName: kotlin.String,
       |        className: kotlin.String,

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/triggers/TriggerNotificationTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/triggers/TriggerNotificationTest.kt
@@ -41,7 +41,14 @@ class MutatorQueryFunctionTest {
 
     Truth.assertThat(generator.type().toString())
         .isEqualTo("""
-      |private inner class InsertData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class InsertData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |INSERT INTO data
+      |            |VALUES (?, ?)
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
+      |            }
+      |
       |    fun execute(id: kotlin.Long?, value: kotlin.String?) {
       |        statement.bindLong(1, id)
       |        statement.bindString(2, value)
@@ -83,7 +90,14 @@ class MutatorQueryFunctionTest {
 
     Truth.assertThat(generator.type().toString())
         .isEqualTo("""
-      |private inner class DeleteData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class DeleteData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |DELETE FROM data
+      |            |WHERE id = ?
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE, 1)
+      |            }
+      |
       |    fun execute(id: kotlin.Long) {
       |        statement.bindLong(1, id)
       |        statement.execute()
@@ -124,7 +138,15 @@ class MutatorQueryFunctionTest {
 
     Truth.assertThat(generator.type().toString())
         .isEqualTo("""
-      |private inner class DeleteData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class DeleteData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |UPDATE data
+      |            |SET value = ?
+      |            |WHERE id = ?
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
+      |            }
+      |
       |    fun execute(value: kotlin.String?, id: kotlin.Long) {
       |        statement.bindString(1, value)
       |        statement.bindLong(2, id)
@@ -166,7 +188,15 @@ class MutatorQueryFunctionTest {
 
     Truth.assertThat(generator.type().toString())
         .isEqualTo("""
-      |private inner class DeleteData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class DeleteData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |UPDATE data
+      |            |SET value = ?
+      |            |WHERE id = ?
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
+      |            }
+      |
       |    fun execute(value: kotlin.String?, id: kotlin.Long) {
       |        statement.bindString(1, value)
       |        statement.bindLong(2, id)
@@ -209,7 +239,15 @@ class MutatorQueryFunctionTest {
 
     Truth.assertThat(generator.type().toString())
         .isEqualTo("""
-      |private inner class DeleteData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class DeleteData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |UPDATE data
+      |            |SET value = ?
+      |            |WHERE id = ?
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
+      |            }
+      |
       |    fun execute(value: kotlin.String?, id: kotlin.Long) {
       |        statement.bindString(1, value)
       |        statement.bindLong(2, id)
@@ -252,7 +290,15 @@ class MutatorQueryFunctionTest {
 
     Truth.assertThat(generator.type().toString())
         .isEqualTo("""
-      |private inner class DeleteData(private val statement: com.squareup.sqldelight.db.SqlPreparedStatement) {
+      |private inner class DeleteData {
+      |    private val statement: com.squareup.sqldelight.db.SqlPreparedStatement by lazy {
+      |            database.getConnection().prepareStatement(""${'"'}
+      |            |UPDATE data
+      |            |SET value = ?
+      |            |WHERE id = ?
+      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
+      |            }
+      |
       |    fun execute(value: kotlin.String?, id: kotlin.Long) {
       |        statement.bindString(1, value)
       |        statement.bindLong(2, id)

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
@@ -1,0 +1,73 @@
+plugins {
+  id 'com.android.library'
+  id 'org.jetbrains.kotlin.multiplatform'
+  id 'com.squareup.sqldelight'
+}
+
+apply from: '../../../../gradle/dependencies.gradle'
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+  jcenter()
+}
+
+android {
+  compileSdkVersion versions.compileSdk
+
+  defaultConfig {
+    minSdkVersion versions.minSdk
+    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+  }
+
+  lintOptions {
+    textOutput 'stdout'
+    textReport true
+  }
+
+  compileOptions {
+    targetCompatibility 1.8
+    sourceCompatibility 1.8
+  }
+}
+
+sqldelight {
+  packageName = "com.squareup.sqldelight.integration"
+}
+
+kotlin {
+  targets {
+    fromPreset(presets.android, 'android')
+  }
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation deps.kotlin.stdlib.common
+      }
+    }
+    commonTest {
+      dependencies {
+        implementation deps.kotlin.test.common
+        implementation deps.kotlin.test.commonAnnotations
+        implementation deps.stately
+        implementation "com.squareup.sqldelight:runtime:1.0.0-SNAPSHOT"
+      }
+    }
+    androidMain {
+      dependencies {
+        implementation deps.kotlin.stdlib.jdk
+        implementation "com.squareup.sqldelight:sqlite-driver:1.0.0-SNAPSHOT"
+      }
+    }
+    androidTest {
+      dependencies {
+        implementation deps.kotlin.test.junit
+        implementation "com.squareup.sqldelight:sqlite-driver:1.0.0-SNAPSHOT"
+      }
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
@@ -1,5 +1,4 @@
 plugins {
-  id 'com.android.library'
   id 'org.jetbrains.kotlin.multiplatform'
   id 'com.squareup.sqldelight'
 }
@@ -15,24 +14,6 @@ repositories {
   jcenter()
 }
 
-android {
-  compileSdkVersion versions.compileSdk
-
-  defaultConfig {
-    minSdkVersion versions.minSdk
-    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
-  }
-
-  lintOptions {
-    textOutput 'stdout'
-    textReport true
-  }
-
-  compileOptions {
-    targetCompatibility 1.8
-    sourceCompatibility 1.8
-  }
-}
 
 sqldelight {
   packageName = "com.squareup.sqldelight.integration"
@@ -40,8 +21,6 @@ sqldelight {
 
 kotlin {
   targets {
-    fromPreset(presets.android, 'android')
-
     def buildForDevice = project.findProperty("device")?.toBoolean() ?: false
     def iosPreset = (buildForDevice) ? presets.iosArm64 : presets.iosX64
     fromPreset(iosPreset, 'ios') {
@@ -62,19 +41,8 @@ kotlin {
       dependencies {
         implementation deps.kotlin.test.common
         implementation deps.kotlin.test.commonAnnotations
+        implementation deps.stately
         implementation "com.squareup.sqldelight:runtime:1.0.0-SNAPSHOT"
-      }
-    }
-    androidMain {
-      dependencies {
-        implementation deps.kotlin.stdlib.jdk
-        implementation "com.squareup.sqldelight:sqlite-driver:1.0.0-SNAPSHOT"
-      }
-    }
-    androidTest {
-      dependencies {
-        implementation deps.kotlin.test.junit
-        implementation "com.squareup.sqldelight:sqlite-driver:1.0.0-SNAPSHOT"
       }
     }
     iosMain {

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonTest/kotlin/com/squareup/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonTest/kotlin/com/squareup/sqldelight/integration/IntegrationTests.kt
@@ -7,6 +7,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.test.assertEquals
+import co.touchlab.stately.freeze
 
 class IntegrationTests {
   private lateinit var queryWrapper: QueryWrapper
@@ -25,6 +26,7 @@ class IntegrationTests {
     QueryWrapper.Schema.create(database.getConnection())
 
     queryWrapper = QueryWrapper(database, NullableTypes.Adapter(listAdapter))
+    queryWrapper.freeze()
     personQueries = queryWrapper.personQueries
     keywordsQueries = queryWrapper.sqliteKeywordsQueries
     nullableTypesQueries = queryWrapper.nullableTypesQueries

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/IntegrationTest.kt
@@ -87,11 +87,13 @@ class IntegrationTest {
   @Test fun `integration test android target of a multiplatform project`() {
     val androidHome = androidHome()
     val integrationRoot = File("src/test/integration-multiplatform")
+    val buildGradle = File(integrationRoot, "build.gradle").apply { deleteOnExit() }
     File(integrationRoot, "local.properties").writeText("sdk.dir=$androidHome\n")
     val gradleRoot = File(integrationRoot, "gradle").apply {
       mkdir()
     }
     File("../gradle/wrapper").copyRecursively(File(gradleRoot, "wrapper"), true)
+    File(integrationRoot, "android-build.gradle").copyTo(buildGradle, overwrite = true)
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
@@ -104,13 +106,14 @@ class IntegrationTest {
 
   @Test
   @Category(IosTest::class)
-  @Ignore // This bad boy fails currently. TIME TO FIX.
   fun `integration test ios target of a multiplatform project`() {
     val integrationRoot = File("src/test/integration-multiplatform")
+    val buildGradle = File(integrationRoot, "build.gradle").apply { deleteOnExit() }
     val gradleRoot = File(integrationRoot, "gradle").apply {
       mkdir()
     }
     File("../gradle/wrapper").copyRecursively(File(gradleRoot, "wrapper"), true)
+    File(integrationRoot, "ios-build.gradle").copyTo(buildGradle, overwrite = true)
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)

--- a/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
+++ b/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
@@ -19,7 +19,6 @@ import co.touchlab.stately.collections.SharedSet
 import co.touchlab.stately.concurrency.AtomicBoolean
 import co.touchlab.stately.concurrency.AtomicReference
 import co.touchlab.stately.concurrency.ThreadLocalRef
-import co.touchlab.stately.freeze
 import com.squareup.sqldelight.Transacter.Transaction
 import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.internal.QueryList
@@ -28,10 +27,6 @@ import com.squareup.sqldelight.internal.QueryList
  * A transaction-aware [SqlDatabase] wrapper which can begin a [Transaction] on the current connection.
  */
 abstract class Transacter(private val database: SqlDatabase) {
-  init {
-    freeze()
-  }
-
   /**
    * For internal use, performs [function] immediately if there is no active [Transaction] on this
    * thread, otherwise defers [function] to happen on transaction commit.


### PR DESCRIPTION
 - Transacter doesn't freeze itself. This was causing errors where subclasses
   would throw Immutability exceptions when they tried to set their own
   properties
 - Inner mutator classes are not lazy, but the prepared statements are. Having
   a lazy delegate create a new inner class is disallowed on frozen objects.
 - Will explore freezing the QueryWrapper by default later.