### PR TITLE
Include both exception during rollback failures

### DIFF
--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
@@ -6,9 +6,10 @@ import com.squareup.sqldelight.db.SqlDatabase.Schema
 import com.squareup.sqldelight.db.SqlDatabaseConnection
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
 
 abstract class TransacterTest {
   private lateinit var transacter: Transacter
@@ -176,17 +177,21 @@ abstract class TransacterTest {
     }
   }
 
-  @Ignore @Test
+  @Test
   fun `An exception thrown in postRollback function is combined with the exception in the main body`() {
+    class ExceptionA : RuntimeException()
+    class ExceptionB : RuntimeException()
     try {
       transacter.transaction {
         afterRollback {
-          throw RuntimeException("afterRollback exception")
+          throw ExceptionA()
         }
-        throw RuntimeException("transaction exception")
+        throw ExceptionB()
       }
-    } catch (e: RuntimeException) {
-      // Verify it is a composite exception with both exceptions printed in the stack trace.
+      fail("Should have thrown!")
+    } catch (e: Throwable) {
+      assertTrue("Exception thrown in body not in message($e)") { e.toString().contains("ExceptionA") }
+      assertTrue("Exception thrown in rollback not in message($e)") { e.toString().contains("ExceptionB") }
     }
   }
 }

--- a/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
+++ b/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
@@ -81,18 +81,30 @@ abstract class Transacter(private val database: SqlDatabase) {
       throw IllegalStateException("Already in a transaction")
     }
 
+    var thrownException: Throwable? = null
+
     try {
       transaction.transacter = this
       transaction.body()
       transaction.successful = true
     } catch (e: RollbackException) {
       if (enclosing != null) throw e
+      thrownException = e
+    } catch (e: Throwable) {
+      thrownException = e
     } finally {
       transaction.endTransaction()
       if (enclosing == null) {
         if (!transaction.successful || !transaction.childrenSuccessful) {
           // TODO: If this throws, and we threw in [body] then create a composite exception.
-          transaction.postRollbackHooks.forEach { it.value!!.invoke() }
+          try {
+            transaction.postRollbackHooks.forEach { it.value!!.invoke() }
+          } catch (rollbackException: Throwable) {
+            thrownException?.let {
+              throw Throwable("Exception while rolling back from an exception.\nOriginal exception: $thrownException\nwith cause ${thrownException.cause}\n\nRollback exception: $rollbackException", rollbackException)
+            }
+            throw rollbackException
+          }
           transaction.postRollbackHooks.clear()
         } else {
           transaction.queriesToUpdate.forEach { it.notifyDataChanged() }

--- a/sqldelight-runtime/src/jvmTest/kotlin/com/squareup/sqldelight/TransacterTest.kt
+++ b/sqldelight-runtime/src/jvmTest/kotlin/com/squareup/sqldelight/TransacterTest.kt
@@ -4,9 +4,10 @@ import com.squareup.sqldelight.db.SqlDatabase
 import com.squareup.sqldelight.db.SqlDatabaseConnection
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
 
 class TransacterTest {
   private lateinit var transacter: Transacter
@@ -164,16 +165,21 @@ class TransacterTest {
     }
   }
 
-  @Ignore @Test fun `An exception thrown in postRollback function is combined with the exception in the main body`() {
+  @Test
+  fun `An exception thrown in postRollback function is combined with the exception in the main body`() {
+    class ExceptionA : RuntimeException()
+    class ExceptionB : RuntimeException()
     try {
       transacter.transaction {
         afterRollback {
-          throw RuntimeException("afterRollback exception")
+          throw ExceptionA()
         }
-        throw RuntimeException("transaction exception")
+        throw ExceptionB()
       }
-    } catch (e: RuntimeException) {
-      // Verify it is a composite exception with both exceptions printed in the stack trace.
+      fail("Should have thrown!")
+    } catch (e: Throwable) {
+      assertTrue("Exception thrown in body not in message($e)") { e.toString().contains("ExceptionA") }
+      assertTrue("Exception thrown in rollback not in message($e)") { e.toString().contains("ExceptionB") }
     }
   }
 }


### PR DESCRIPTION
 - Theres no initCause on kotlin throwables
 - Theres no printStackTrace on kotlin throwables
 - Given those I think this is the best I can do