### PR TITLE
Modify driver api to always execute sql

### DIFF
--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
@@ -20,22 +20,28 @@ class AndroidDriverTest : DriverTest() {
   @Test
   fun `cached statement can be reused`() {
     val database = AndroidSqlDatabase(schema, RuntimeEnvironment.application, cacheSize = 1)
-    val statement = database.prepareStatement(1, "SELECT * FROM test", SqlPreparedStatement.Type.SELECT, 0)
+    lateinit var bindable: SqlPreparedStatement
+    database.executeQuery(1, "SELECT * FROM test", 0) {
+      bindable = this
+    }
 
-    val statement2 = database.prepareStatement(1, "SELECT * FROM test", SqlPreparedStatement.Type.SELECT, 0)
-
-    assertSame(statement, statement2)
+    database.executeQuery(1, "SELECT * FROM test", 0) {
+      assertSame(bindable, this)
+    }
   }
 
   @Test
   fun `cached statement is evicted and closed`() {
     val database = AndroidSqlDatabase(schema, RuntimeEnvironment.application, cacheSize = 1)
-    val statement = database.prepareStatement(1, "SELECT * FROM test", SqlPreparedStatement.Type.SELECT, 0)
+    lateinit var bindable: SqlPreparedStatement
+    database.executeQuery(1, "SELECT * FROM test", 0) {
+      bindable = this
+    }
 
-    database.prepareStatement(2, "SELECT * FROM test", SqlPreparedStatement.Type.SELECT, 0)
+    database.executeQuery(2, "SELECT * FROM test", 0)
 
-    val statement3 = database.prepareStatement(1, "SELECT * FROM test", SqlPreparedStatement.Type.SELECT, 0)
-
-    assertNotSame(statement, statement3)
+    database.executeQuery(1, "SELECT * FROM test", 0) {
+      assertNotSame(bindable, this)
+    }
   }
 }

--- a/drivers/ios-driver/src/nativeMain/kotlin/com/squareup/sqldelight/drivers/ios/SqliterPreparedStatement.kt
+++ b/drivers/ios-driver/src/nativeMain/kotlin/com/squareup/sqldelight/drivers/ios/SqliterPreparedStatement.kt
@@ -1,73 +1,31 @@
 package com.squareup.sqldelight.drivers.ios
 
-import co.touchlab.sqliter.Cursor
 import co.touchlab.sqliter.Statement
 import co.touchlab.sqliter.bindBlob
 import co.touchlab.sqliter.bindDouble
 import co.touchlab.sqliter.bindLong
 import co.touchlab.sqliter.bindString
-import co.touchlab.stately.concurrency.AtomicBoolean
-import com.squareup.sqldelight.db.SqlCursor
 import com.squareup.sqldelight.db.SqlPreparedStatement
 
 /**
  * @param [recycle] A function which recycles any resources this statement is backed by.
  */
 internal class SqliterStatement(
-  private val statement: Statement,
-  private val track: (Cursor) -> Unit,
-  private val recycle: (Statement) -> Unit
+  private val statement: Statement
 ) : SqlPreparedStatement {
-  private val executed = AtomicBoolean(false)
-
   override fun bindBytes(index: Int, value: ByteArray?) {
-    bindFailRecycle {
-      statement.bindBlob(index, value)
-    }
+    statement.bindBlob(index, value)
   }
 
   override fun bindLong(index: Int, value: Long?) {
-    bindFailRecycle {
-      statement.bindLong(index, value)
-    }
+    statement.bindLong(index, value)
   }
 
   override fun bindDouble(index: Int, value: Double?) {
-    bindFailRecycle {
-      statement.bindDouble(index, value)
-    }
+    statement.bindDouble(index, value)
   }
 
   override fun bindString(index: Int, value: String?) {
-    bindFailRecycle {
-      statement.bindString(index, value)
-    }
-  }
-
-  private inline fun bindFailRecycle(block: () -> Unit) {
-    try {
-      block()
-    } catch (t: Throwable) {
-      recycle(statement)
-      throw t
-    }
-  }
-
-  override fun executeQuery(): SqlCursor {
-    if (executed.value) throw IllegalStateException("Cannot call execute multiple times.")
-    executed.value = true
-
-    val cursor = statement.query()
-    track(cursor)
-    return SqliterSqlCursor(cursor, { recycle(statement) })
-  }
-
-  override fun execute() {
-    if (executed.value) throw IllegalStateException("Cannot call execute multiple times.")
-    executed.value = true
-
-    statement.execute()
-    statement.resetStatement()
-    recycle(statement)
+    statement.bindString(index, value)
   }
 }

--- a/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosDriverTest.kt
+++ b/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosDriverTest.kt
@@ -2,7 +2,6 @@ package com.squareup.sqldelight.drivers.ios
 
 import co.touchlab.sqliter.NativeFileContext.deleteDatabase
 import com.squareup.sqldelight.db.SqlDatabase
-import com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT
 import com.squareup.sqldelight.driver.test.DriverTest
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -28,7 +27,7 @@ class IosDriverTest : DriverTest() {
 
   // Sanity check of the driver.
   @Test fun basicTest() {
-    val cursor = database.prepareStatement(0, "SELECT 1", SELECT, 0).executeQuery()
+    val cursor = database.executeQuery(0, "SELECT 1", 0)
     cursor.next()
     assertEquals(1, cursor.getLong(0))
     cursor.close()

--- a/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/LazyDbBaseTest.kt
+++ b/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/LazyDbBaseTest.kt
@@ -1,13 +1,12 @@
 package com.squareup.sqldelight.drivers.ios
 
-import co.touchlab.sqliter.NativeFileContext.deleteDatabase
 import co.touchlab.sqliter.DatabaseConfiguration
 import co.touchlab.sqliter.DatabaseManager
+import co.touchlab.sqliter.NativeFileContext.deleteDatabase
 import co.touchlab.sqliter.createDatabaseManager
 import co.touchlab.stately.freeze
-import com.squareup.sqldelight.db.SqlDatabase
-import com.squareup.sqldelight.db.SqlPreparedStatement
 import com.squareup.sqldelight.Transacter
+import com.squareup.sqldelight.db.SqlDatabase
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
@@ -41,17 +40,13 @@ abstract class LazyDbBaseTest {
       override val version: Int = 1
 
       override fun create(db: SqlDatabase) {
-        db.prepareStatement(20,
-            """
+        db.execute(20, """
                   |CREATE TABLE test (
                   |  id INTEGER PRIMARY KEY,
                   |  value TEXT
                   |);
-                """.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0
-        )
-            .execute()
-        db.prepareStatement(30,
-            """
+                """.trimMargin(), 0)
+        db.execute(30, """
                   |CREATE TABLE nullability_test (
                   |  id INTEGER PRIMARY KEY,
                   |  integer_value INTEGER,
@@ -59,9 +54,7 @@ abstract class LazyDbBaseTest {
                   |  blob_value BLOB,
                   |  real_value REAL
                   |);
-                """.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0
-        )
-            .execute()
+                """.trimMargin(), 0)
       }
 
       override fun migrate(

--- a/drivers/sqlite-driver/build.gradle
+++ b/drivers/sqlite-driver/build.gradle
@@ -5,6 +5,7 @@ archivesBaseName = 'sqldelight-sqlite-driver'
 dependencies {
   implementation project(':sqldelight-runtime')
   
+  implementation deps.kotlin.stdlib.jdk
   implementation deps.sqliteJdbc
   implementation deps.statelyJvm
   

--- a/drivers/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/SqliteJdbcOpenHelper.kt
+++ b/drivers/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/SqliteJdbcOpenHelper.kt
@@ -19,13 +19,26 @@ class SqliteJdbcOpenHelper constructor(
 
   override fun close() = connection.close()
 
-  override fun prepareStatement(
+  override fun execute(
     identifier: Int?,
     sql: String,
-    type: SqlPreparedStatement.Type,
-    parameters: Int
-  ): SqlPreparedStatement {
+    parameters: Int,
+    binders: (SqlPreparedStatement.() -> Unit)?
+  ) {
+    SqliteJdbcPreparedStatement(connection.prepareStatement(sql))
+        .apply { if (binders != null) this.binders() }
+        .execute()
+  }
+
+  override fun executeQuery(
+    identifier: Int?,
+    sql: String,
+    parameters: Int,
+    binders: (SqlPreparedStatement.() -> Unit)?
+  ): SqlCursor {
     return SqliteJdbcPreparedStatement(connection.prepareStatement(sql))
+        .apply { if (binders != null) this.binders() }
+        .executeQuery()
   }
 
   override fun newTransaction(): Transacter.Transaction {
@@ -93,9 +106,9 @@ private class SqliteJdbcPreparedStatement(
     }
   }
 
-  override fun executeQuery() = SqliteJdbcCursor(preparedStatement.executeQuery())
+  internal fun executeQuery() = SqliteJdbcCursor(preparedStatement.executeQuery())
 
-  override fun execute() {
+  internal fun execute() {
     preparedStatement.execute()
   }
 }

--- a/extensions/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/QueryObservableTest.kt
+++ b/extensions/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/QueryObservableTest.kt
@@ -12,20 +12,9 @@ import org.junit.Test
 class QueryObservableTest {
   @Test fun mapToListThrowsFromQueryRun() {
     val error = IllegalStateException("test exception")
-    val preparedStatement = object : SqlPreparedStatement {
-      override fun bindBytes(index: Int, bytes: ByteArray?) = throw AssertionError()
-      override fun bindLong(index: Int, long: Long?) = throw AssertionError()
-      override fun bindDouble(index: Int, double: Double?) = throw AssertionError()
-      override fun bindString(index: Int, string: String?) = throw AssertionError()
-      override fun execute() = throw AssertionError()
-
-      override fun executeQuery(): SqlCursor {
-        throw error
-      }
-    }
 
     val query = object : Query<Any>(copyOnWriteList(), { throw AssertionError("Must not be called") }) {
-      override fun createStatement() = preparedStatement
+      override fun execute() = throw error
     }
 
     query.asObservable(Schedulers.trampoline()).mapToList()

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/QueryWrapper.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/QueryWrapper.kt
@@ -2,7 +2,6 @@ package com.example
 
 import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.db.SqlDatabase
-import com.squareup.sqldelight.db.SqlPreparedStatement
 import kotlin.Int
 
 class QueryWrapper(
@@ -19,20 +18,20 @@ class QueryWrapper(
             get() = 1
 
         override fun create(database: SqlDatabase) {
-            database.prepareStatement(null, """
+            database.execute(null, """
                     |CREATE TABLE team (
                     |  name TEXT PRIMARY KEY NOT NULL,
                     |  captain INTEGER UNIQUE NOT NULL REFERENCES player(number),
                     |  inner_type TEXT,
                     |  coach TEXT NOT NULL
                     |)
-                    """.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
-            database.prepareStatement(null, """
+                    """.trimMargin(), 0)
+            database.execute(null, """
                     |INSERT INTO team
                     |VALUES ('Anaheim Ducks', 15, NULL, 'Randy Carlyle'),
                     |       ('Ottawa Senators', 65, 'ONE', 'Guy Boucher')
-                    """.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
-            database.prepareStatement(null, """
+                    """.trimMargin(), 0)
+            database.execute(null, """
                     |CREATE TABLE player (
                     |  name TEXT NOT NULL,
                     |  number INTEGER NOT NULL,
@@ -40,12 +39,12 @@ class QueryWrapper(
                     |  shoots TEXT NOT NULL,
                     |  PRIMARY KEY (team, number)
                     |)
-                    """.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
-            database.prepareStatement(null, """
+                    """.trimMargin(), 0)
+            database.execute(null, """
                     |INSERT INTO player
                     |VALUES ('Ryan Getzlaf', 15, 'Anaheim Ducks', 'RIGHT'),
                     |       ('Erik Karlsson', 65, 'Ottawa Senators', 'RIGHT')
-                    """.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
+                    """.trimMargin(), 0)
         }
 
         override fun migrate(

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -5,7 +5,6 @@ import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.core.integration.Shoots
 import com.squareup.sqldelight.db.SqlCursor
 import com.squareup.sqldelight.db.SqlDatabase
-import com.squareup.sqldelight.db.SqlPreparedStatement
 import kotlin.Any
 import kotlin.Long
 import kotlin.String
@@ -53,28 +52,24 @@ class TeamQueries(private val queryWrapper: QueryWrapper, private val database: 
 
     private inner class TeamForCoach<out T : Any>(private val coach: String, mapper: (SqlCursor) ->
             T) : Query<T>(teamForCoach, mapper) {
-        override fun createStatement(): SqlPreparedStatement {
-            val statement = database.prepareStatement(80, """
-                    |SELECT *
-                    |FROM team
-                    |WHERE coach = ?1
-                    """.trimMargin(), SqlPreparedStatement.Type.SELECT, 1)
-            statement.bindString(1, coach)
-            return statement
+        override fun execute(): SqlCursor = database.executeQuery(80, """
+        |SELECT *
+        |FROM team
+        |WHERE coach = ?1
+        """.trimMargin(), 1) {
+            bindString(1, coach)
         }
     }
 
     private inner class ForInnerType<out T : Any>(private val inner_type: Shoots.Type?, mapper:
             (SqlCursor) -> T) : Query<T>(forInnerType, mapper) {
-        override fun createStatement(): SqlPreparedStatement {
-            val statement = database.prepareStatement(81, """
-                    |SELECT *
-                    |FROM team
-                    |WHERE inner_type ${ if (inner_type == null) "IS" else "=" } ?1
-                    """.trimMargin(), SqlPreparedStatement.Type.SELECT, 1)
-            statement.bindString(1, if (inner_type == null) null else
+        override fun execute(): SqlCursor = database.executeQuery(81, """
+        |SELECT *
+        |FROM team
+        |WHERE inner_type ${ if (inner_type == null) "IS" else "=" } ?1
+        """.trimMargin(), 1) {
+            bindString(1, if (inner_type == null) null else
                     queryWrapper.teamAdapter.inner_typeAdapter.encode(inner_type))
-            return statement
         }
     }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/ExecuteQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/ExecuteQueryGenerator.kt
@@ -1,21 +1,11 @@
 package com.squareup.sqldelight.core.compiler
 
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.joinToCode
 import com.squareup.sqldelight.core.compiler.model.NamedExecute
-import com.squareup.sqldelight.core.lang.DATABASE_NAME
-import com.squareup.sqldelight.core.lang.EXECUTE_METHOD
-import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.STATEMENT_NAME
-import com.squareup.sqldelight.core.lang.psi.InsertStmtMixin
-import com.squareup.sqldelight.core.lang.util.isArrayParameter
-import com.squareup.sqldelight.core.lang.util.rawSqlText
 
 open class ExecuteQueryGenerator(private val query: NamedExecute) : QueryGenerator(query) {
   protected open fun FunSpec.Builder.notifyQueries() = this
@@ -29,8 +19,7 @@ open class ExecuteQueryGenerator(private val query: NamedExecute) : QueryGenerat
         .addParameters(query.parameters.map {
           ParameterSpec.builder(it.name, it.argumentType()).build()
         })
-        .addCode(preparedStatementBinder())
-        .addStatement("$STATEMENT_NAME.execute()")
+        .addCode(executeBlock())
         .notifyQueries()
         .build()
   }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/MutatorQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/MutatorQueryGenerator.kt
@@ -1,26 +1,12 @@
 package com.squareup.sqldelight.core.compiler
 
 import com.alecstrong.sqlite.psi.core.psi.SqliteTypes
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier.INNER
-import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.sqldelight.core.compiler.model.NamedMutator
 import com.squareup.sqldelight.core.compiler.model.NamedQuery
-import com.squareup.sqldelight.core.lang.DATABASE_NAME
-import com.squareup.sqldelight.core.lang.EXECUTE_METHOD
-import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.STATEMENT_NAME
 import com.squareup.sqldelight.core.lang.SqlDelightFile
-import com.squareup.sqldelight.core.lang.psi.InsertStmtMixin
 import com.squareup.sqldelight.core.lang.util.childOfType
-import com.squareup.sqldelight.core.lang.util.isArrayParameter
-import com.squareup.sqldelight.core.lang.util.rawSqlText
 import com.squareup.sqldelight.core.lang.util.referencedTables
 import com.squareup.sqldelight.core.lang.util.sqFile
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryWrapperGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryWrapperGenerator.kt
@@ -29,12 +29,11 @@ import com.squareup.sqldelight.core.SqlDelightException
 import com.squareup.sqldelight.core.SqlDelightFileIndex
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
 import com.squareup.sqldelight.core.lang.ADAPTER_NAME
-import com.squareup.sqldelight.core.lang.DATABASE_SCHEMA_TYPE
 import com.squareup.sqldelight.core.lang.DATABASE_NAME
+import com.squareup.sqldelight.core.lang.DATABASE_SCHEMA_TYPE
 import com.squareup.sqldelight.core.lang.DATABASE_TYPE
 import com.squareup.sqldelight.core.lang.MigrationFile
 import com.squareup.sqldelight.core.lang.QUERY_WRAPPER_NAME
-import com.squareup.sqldelight.core.lang.STATEMENT_TYPE_ENUM
 import com.squareup.sqldelight.core.lang.SqlDelightFile
 import com.squareup.sqldelight.core.lang.TRANSACTER_TYPE
 import com.squareup.sqldelight.core.lang.adapterName
@@ -99,10 +98,7 @@ internal class QueryWrapperGenerator(module: Module, sourceFile: SqlDelightFile)
 
     sourceFolders.flatMap { it.findChildrenOfType<SqlDelightFile>() }
         .forInitializationStatements { sqlText ->
-          createFunction.addStatement(
-              "$DATABASE_NAME.prepareStatement(null, %S, %T.EXECUTE, 0).execute()",
-              sqlText, STATEMENT_TYPE_ENUM
-          )
+          createFunction.addStatement("$DATABASE_NAME.execute(null, %S, 0)", sqlText)
         }
 
     var maxVersion = 1
@@ -120,10 +116,7 @@ internal class QueryWrapperGenerator(module: Module, sourceFile: SqlDelightFile)
               oldVersion, newVersion
           )
           migrationFile.sqliteStatements().forEach {
-            migrateFunction.addStatement(
-                "$DATABASE_NAME.prepareStatement(null, %S, %T.EXECUTE, 0).execute()",
-                it.rawSqlText(), STATEMENT_TYPE_ENUM
-            )
+            migrateFunction.addStatement("$DATABASE_NAME.execute(null, %S, 0)", it.rawSqlText())
           }
           migrateFunction.endControlFlow()
         }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -31,15 +31,14 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.sqldelight.core.compiler.model.NamedQuery
+import com.squareup.sqldelight.core.lang.CURSOR_NAME
+import com.squareup.sqldelight.core.lang.CURSOR_TYPE
 import com.squareup.sqldelight.core.lang.DATABASE_NAME
+import com.squareup.sqldelight.core.lang.EXECUTE_METHOD
 import com.squareup.sqldelight.core.lang.IMPLEMENTATION_NAME
 import com.squareup.sqldelight.core.lang.MAPPER_NAME
 import com.squareup.sqldelight.core.lang.QUERY_LIST_TYPE
 import com.squareup.sqldelight.core.lang.QUERY_TYPE
-import com.squareup.sqldelight.core.lang.CURSOR_NAME
-import com.squareup.sqldelight.core.lang.CURSOR_TYPE
-import com.squareup.sqldelight.core.lang.STATEMENT_NAME
-import com.squareup.sqldelight.core.lang.STATEMENT_TYPE
 import com.squareup.sqldelight.core.lang.util.rawSqlText
 
 class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query) {
@@ -192,11 +191,10 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
     // Query<T>
     queryType.superclass(QUERY_TYPE.parameterizedBy(returnType))
 
-    val createStatementFunction = FunSpec.builder("createStatement")
+    val createStatementFunction = FunSpec.builder(EXECUTE_METHOD)
         .addModifiers(OVERRIDE)
-        .returns(STATEMENT_TYPE)
-        .addCode(preparedStatementBinder())
-        .addStatement("return $STATEMENT_NAME")
+        .returns(CURSOR_TYPE)
+        .addCode(executeBlock())
 
     // For each bind argument the query has.
     query.arguments.sortedBy { it.index }.forEach { (_, parameter) ->

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
@@ -155,8 +155,6 @@ abstract class BindableQuery(
         .joinToString(separator = "\n", transform = String::trim)
   }
 
-  internal abstract fun type(): CodeBlock
-
   internal data class Argument(
     val index: Int,
     val type: IntermediateType,

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedExecute.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedExecute.kt
@@ -1,8 +1,6 @@
 package com.squareup.sqldelight.core.compiler.model
 
 import com.intellij.psi.PsiElement
-import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.sqldelight.core.lang.STATEMENT_TYPE_ENUM
 import com.squareup.sqldelight.core.lang.psi.StmtIdentifierMixin
 
 open class NamedExecute(
@@ -10,8 +8,4 @@ open class NamedExecute(
   statement: PsiElement
 ) : BindableQuery(identifier, statement) {
   val name = identifier.name!!
-
-  override fun type(): CodeBlock {
-    return CodeBlock.of("%T.EXECUTE", STATEMENT_TYPE_ENUM)
-  }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedMutator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedMutator.kt
@@ -20,8 +20,6 @@ import com.alecstrong.sqlite.psi.core.psi.SqliteInsertStmt
 import com.alecstrong.sqlite.psi.core.psi.SqliteTableName
 import com.alecstrong.sqlite.psi.core.psi.SqliteUpdateStmtLimited
 import com.intellij.psi.PsiElement
-import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.sqldelight.core.lang.STATEMENT_TYPE_ENUM
 import com.squareup.sqldelight.core.lang.psi.StmtIdentifierMixin
 import com.squareup.sqldelight.core.lang.util.referencedTables
 
@@ -37,21 +35,15 @@ sealed class NamedMutator(
   class Insert(
     insert: SqliteInsertStmt,
     identifier: StmtIdentifierMixin
-  ) : NamedMutator(insert, identifier, insert.tableName) {
-    override fun type() = CodeBlock.of("%T.INSERT", STATEMENT_TYPE_ENUM)
-  }
+  ) : NamedMutator(insert, identifier, insert.tableName)
 
   class Delete(
     delete: SqliteDeleteStmtLimited,
     identifier: StmtIdentifierMixin
-  ) : NamedMutator(delete, identifier, delete.qualifiedTableName.tableName) {
-    override fun type() = CodeBlock.of("%T.DELETE", STATEMENT_TYPE_ENUM)
-  }
+  ) : NamedMutator(delete, identifier, delete.qualifiedTableName.tableName)
 
   class Update(
     internal val update: SqliteUpdateStmtLimited,
     identifier: StmtIdentifierMixin
-  ) : NamedMutator(update, identifier, update.qualifiedTableName.tableName) {
-    override fun type() = CodeBlock.of("%T.UPDATE", STATEMENT_TYPE_ENUM)
-  }
+  ) : NamedMutator(update, identifier, update.qualifiedTableName.tableName)
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
@@ -33,7 +33,6 @@ import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.NULL
 import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.REAL
 import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.QUERY_WRAPPER_NAME
-import com.squareup.sqldelight.core.lang.STATEMENT_TYPE_ENUM
 import com.squareup.sqldelight.core.lang.queriesName
 import com.squareup.sqldelight.core.lang.util.name
 import com.squareup.sqldelight.core.lang.util.sqFile
@@ -120,8 +119,6 @@ data class NamedQuery(
 
   internal val queryProperty =
       CodeBlock.of("$QUERY_WRAPPER_NAME.${select.sqFile().queriesName}.$name")
-
-  override fun type() = CodeBlock.of("%T.SELECT", STATEMENT_TYPE_ENUM)
 
   private fun resultColumns(valuesList: List<SqliteValuesExpression>): List<IntermediateType> {
     return valuesList.fold(emptyList(), { results, values ->

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
@@ -23,10 +23,6 @@ internal val ADAPTER_NAME = "Adapter"
 internal val SqliteCreateTableStmt.adapterName
   get() = "${allocateName(tableName)}$ADAPTER_NAME"
 
-internal val STATEMENT_NAME = "statement"
-internal val STATEMENT_TYPE = ClassName("com.squareup.sqldelight.db", "SqlPreparedStatement")
-internal val STATEMENT_TYPE_ENUM = STATEMENT_TYPE.nestedClass("Type")
-
 internal val QUERY_TYPE = ClassName("com.squareup.sqldelight", "Query")
 
 internal val QUERY_LIST_TYPE = ClassName("kotlin.collections", "MutableList")
@@ -45,7 +41,3 @@ internal val SqlDelightFile.queriesType
   get() = ClassName(packageName, "${virtualFile!!.nameWithoutExtension.capitalize()}Queries")
 
 internal val TRANSACTER_TYPE = ClassName("com.squareup.sqldelight", "Transacter")
-internal val TRANSACTION_TYPE = TRANSACTER_TYPE.nestedClass("Transaction")
-
-internal fun isUnchangedPropertyName(name: String) =
-  name.startsWith("is") && !name[2].isLowerCase()

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -141,7 +141,6 @@ internal data class IntermediateType(
 
     fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
       return CodeBlock.builder()
-          .add("$STATEMENT_NAME.")
           .add(when (this) {
             INTEGER -> "bindLong"
             REAL -> "bindDouble"

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -40,7 +40,6 @@ class QueriesTypeTest {
       |import com.squareup.sqldelight.Transacter
       |import com.squareup.sqldelight.db.SqlCursor
       |import com.squareup.sqldelight.db.SqlDatabase
-      |import com.squareup.sqldelight.db.SqlPreparedStatement
       |import kotlin.Any
       |import kotlin.Long
       |import kotlin.collections.List
@@ -62,27 +61,25 @@ class QueriesTypeTest {
       |    fun selectForId(id: Long): Query<Data> = selectForId(id, Data::Impl)
       |
       |    fun insertData(id: Long?, value: List?) {
-      |        val statement = database.prepareStatement(${insert.id}, ""${'"'}
-      |                |INSERT INTO data
-      |                |VALUES (?1, ?2)
-      |                ""${'"'}.trimMargin(), SqlPreparedStatement.Type.INSERT, 2)
-      |        statement.bindLong(1, id)
-      |        statement.bindString(2, if (value == null) null else
-      |                queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |        statement.execute()
+      |        database.execute(${insert.id}, ""${'"'}
+      |        |INSERT INTO data
+      |        |VALUES (?1, ?2)
+      |        ""${'"'}.trimMargin(), 2) {
+      |            bindLong(1, id)
+      |            bindString(2, if (value == null) null else
+      |                    queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |        }
       |        notifyQueries(queryWrapper.dataQueries.selectForId)
       |    }
       |
       |    private inner class SelectForId<out T : Any>(private val id: Long, mapper: (SqlCursor) -> T) :
       |            Query<T>(selectForId, mapper) {
-      |        override fun createStatement(): SqlPreparedStatement {
-      |            val statement = database.prepareStatement(${select.id}, ""${'"'}
-      |                    |SELECT *
-      |                    |FROM data
-      |                    |WHERE id = ?1
-      |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.SELECT, 1)
-      |            statement.bindLong(1, id)
-      |            return statement
+      |        override fun execute(): SqlCursor = database.executeQuery(${select.id}, ""${'"'}
+      |        |SELECT *
+      |        |FROM data
+      |        |WHERE id = ?1
+      |        ""${'"'}.trimMargin(), 1) {
+      |            bindLong(1, id)
       |        }
       |    }
       |}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueryWrapperTest.kt
@@ -30,7 +30,6 @@ class QueryWrapperTest {
       |
       |import com.squareup.sqldelight.Transacter
       |import com.squareup.sqldelight.db.SqlDatabase
-      |import com.squareup.sqldelight.db.SqlPreparedStatement
       |import kotlin.Int
       |
       |class QueryWrapper(database: SqlDatabase) : Transacter(database) {
@@ -41,16 +40,16 @@ class QueryWrapperTest {
       |            get() = 1
       |
       |        override fun create(database: SqlDatabase) {
-      |            database.prepareStatement(null, ""${'"'}
+      |            database.execute(null, ""${'"'}
       |                    |CREATE TABLE test_table(
       |                    |  _id INTEGER NOT NULL PRIMARY KEY,
       |                    |  value TEXT
       |                    |)
-      |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
-      |            database.prepareStatement(null, ""${'"'}
+      |                    ""${'"'}.trimMargin(), 0)
+      |            database.execute(null, ""${'"'}
       |                    |INSERT INTO test_table
       |                    |VALUES (1, 'test')
-      |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
+      |                    ""${'"'}.trimMargin(), 0)
       |        }
       |
       |        override fun migrate(
@@ -88,7 +87,6 @@ class QueryWrapperTest {
         |
         |import com.squareup.sqldelight.Transacter
         |import com.squareup.sqldelight.db.SqlDatabase
-        |import com.squareup.sqldelight.db.SqlPreparedStatement
         |import kotlin.Int
         |
         |class QueryWrapper(
@@ -103,18 +101,18 @@ class QueryWrapperTest {
         |            get() = 1
         |
         |        override fun create(database: SqlDatabase) {
-        |            database.prepareStatement(null, ""${'"'}
+        |            database.execute(null, ""${'"'}
         |                    |CREATE TABLE test_table(
         |                    |  _id INTEGER NOT NULL PRIMARY KEY,
         |                    |  value TEXT
         |                    |)
-        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
-        |            database.prepareStatement(null, ""${'"'}
+        |                    ""${'"'}.trimMargin(), 0)
+        |            database.execute(null, ""${'"'}
         |                    |CREATE TABLE test_table2(
         |                    |  _id INTEGER NOT NULL PRIMARY KEY,
         |                    |  value TEXT
         |                    |)
-        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
+        |                    ""${'"'}.trimMargin(), 0)
         |        }
         |
         |        override fun migrate(
@@ -148,7 +146,6 @@ class QueryWrapperTest {
         |
         |import com.squareup.sqldelight.Transacter
         |import com.squareup.sqldelight.db.SqlDatabase
-        |import com.squareup.sqldelight.db.SqlPreparedStatement
         |import kotlin.Int
         |
         |class QueryWrapper(database: SqlDatabase) : Transacter(database) {
@@ -159,15 +156,15 @@ class QueryWrapperTest {
         |            get() = 1
         |
         |        override fun create(database: SqlDatabase) {
-        |            database.prepareStatement(null, ""${'"'}
+        |            database.execute(null, ""${'"'}
         |                    |CREATE VIEW A AS
         |                    |SELECT 1
-        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
-        |            database.prepareStatement(null, ""${'"'}
+        |                    ""${'"'}.trimMargin(), 0)
+        |            database.execute(null, ""${'"'}
         |                    |CREATE VIEW B AS
         |                    |SELECT *
         |                    |FROM A
-        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
+        |                    ""${'"'}.trimMargin(), 0)
         |        }
         |
         |        override fun migrate(
@@ -206,7 +203,6 @@ class QueryWrapperTest {
         |
         |import com.squareup.sqldelight.Transacter
         |import com.squareup.sqldelight.db.SqlDatabase
-        |import com.squareup.sqldelight.db.SqlPreparedStatement
         |import kotlin.Int
         |
         |class QueryWrapper(database: SqlDatabase) : Transacter(database) {
@@ -217,20 +213,19 @@ class QueryWrapperTest {
         |            get() = 1
         |
         |        override fun create(database: SqlDatabase) {
-        |            database.prepareStatement(null, ""${'"'}
+        |            database.execute(null, ""${'"'}
         |                    |CREATE TABLE test (
         |                    |  value TEXT
         |                    |)
-        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
-        |            database.prepareStatement(null, ""${'"'}
+        |                    ""${'"'}.trimMargin(), 0)
+        |            database.execute(null, ""${'"'}
         |                    |CREATE TRIGGER A
         |                    |BEFORE DELETE ON test
         |                    |BEGIN
         |                    |INSERT INTO test DEFAULT VALUES;
         |                    |END
-        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
-        |            database.prepareStatement(null, "CREATE INDEX B ON test(value)",
-        |                    SqlPreparedStatement.Type.EXECUTE, 0).execute()
+        |                    ""${'"'}.trimMargin(), 0)
+        |            database.execute(null, "CREATE INDEX B ON test(value)", 0)
         |        }
         |
         |        override fun migrate(
@@ -269,7 +264,6 @@ class QueryWrapperTest {
         |
         |import com.squareup.sqldelight.Transacter
         |import com.squareup.sqldelight.db.SqlDatabase
-        |import com.squareup.sqldelight.db.SqlPreparedStatement
         |import kotlin.Int
         |
         |class QueryWrapper(database: SqlDatabase) : Transacter(database) {
@@ -280,13 +274,13 @@ class QueryWrapperTest {
         |            get() = 3
         |
         |        override fun create(database: SqlDatabase) {
-        |            database.prepareStatement(null, ""${'"'}
+        |            database.execute(null, ""${'"'}
         |                    |CREATE TABLE test (
         |                    |  value1 TEXT,
         |                    |  value2 TEXT,
         |                    |  value3 REAL
         |                    |)
-        |                    ""${'"'}.trimMargin(), SqlPreparedStatement.Type.EXECUTE, 0).execute()
+        |                    ""${'"'}.trimMargin(), 0)
         |        }
         |
         |        override fun migrate(
@@ -295,12 +289,10 @@ class QueryWrapperTest {
         |            newVersion: Int
         |        ) {
         |            if (oldVersion <= 1 && newVersion > 1) {
-        |                database.prepareStatement(null, "ALTER TABLE test ADD COLUMN value2 TEXT;",
-        |                        SqlPreparedStatement.Type.EXECUTE, 0).execute()
+        |                database.execute(null, "ALTER TABLE test ADD COLUMN value2 TEXT;", 0)
         |            }
         |            if (oldVersion <= 2 && newVersion > 2) {
-        |                database.prepareStatement(null, "ALTER TABLE test ADD COLUMN value3 REAL;",
-        |                        SqlPreparedStatement.Type.EXECUTE, 0).execute()
+        |                database.execute(null, "ALTER TABLE test ADD COLUMN value3 REAL;", 0)
         |            }
         |        }
         |    }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/JavadocTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/JavadocTest.kt
@@ -134,12 +134,12 @@ class JavadocTest {
       | * Insert new value.
       | */
       |fun insertValue(value: kotlin.String) {
-      |    val statement = database.prepareStatement(${insert.id}, ""${'"'}
-      |            |INSERT INTO test(value)
-      |            |VALUES (?1)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
-      |    statement.bindString(1, value)
-      |    statement.execute()
+      |    database.execute(${insert.id}, ""${'"'}
+      |    |INSERT INTO test(value)
+      |    |VALUES (?1)
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindString(1, value)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -163,14 +163,14 @@ class JavadocTest {
       | * Update value by id.
       | */
       |fun updateById(value: kotlin.String, _id: kotlin.Long) {
-      |    val statement = database.prepareStatement(${update.id}, ""${'"'}
-      |            |UPDATE test
-      |            |SET value = ?1
-      |            |WHERE _id = ?2
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
-      |    statement.bindString(1, value)
-      |    statement.bindLong(2, _id)
-      |    statement.execute()
+      |    database.execute(${update.id}, ""${'"'}
+      |    |UPDATE test
+      |    |SET value = ?1
+      |    |WHERE _id = ?2
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindString(1, value)
+      |        bindLong(2, _id)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -192,8 +192,7 @@ class JavadocTest {
       | * Delete all.
       | */
       |fun deleteAll() {
-      |    val statement = database.prepareStatement(${delete.id}, ""${'"'}DELETE FROM test""${'"'}, com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE, 0)
-      |    statement.execute()
+      |    database.execute(${delete.id}, ""${'"'}DELETE FROM test""${'"'}, 0)
       |}
       |""".trimMargin())
   }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -27,13 +27,13 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(id: kotlin.Long?, value: kotlin.collections.List?) {
-      |    val statement = database.prepareStatement(${insert.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?1, ?2)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, id)
-      |    statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |    statement.execute()
+      |    database.execute(${insert.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?1, ?2)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, id)
+      |        bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |    }
       |}
       |""".trimMargin())
   }
@@ -55,13 +55,13 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(id: kotlin.Long?, value: kotlin.collections.List?) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?1, ?2)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, id)
-      |    statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?1, ?2)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, id)
+      |        bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |    }
       |}
       |""".trimMargin())
   }
@@ -82,8 +82,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun deleteData() {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}DELETE FROM data""${'"'}, com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE, 0)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}DELETE FROM data""${'"'}, 0)
       |}
       |""".trimMargin())
   }
@@ -105,13 +104,13 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(data: com.example.Data) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?, ?)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, data.id)
-      |    statement.bindString(2, if (data.value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(data.value!!))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?, ?)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, data.id)
+      |        bindString(2, if (data.value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(data.value!!))
+      |    }
       |}
       |""".trimMargin())
   }
@@ -134,14 +133,14 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun updateData(newValue: kotlin.collections.List?, oldValue: kotlin.collections.List?) {
-      |    val statement = database.prepareStatement(${update.id}, ""${'"'}
-      |            |UPDATE data
-      |            |SET value = ?1
-      |            |WHERE value ${"$"}{ if (oldValue == null) "IS" else "=" } ?2
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
-      |    statement.bindString(1, if (newValue == null) null else queryWrapper.dataAdapter.valueAdapter.encode(newValue))
-      |    statement.bindString(2, if (oldValue == null) null else queryWrapper.dataAdapter.valueAdapter.encode(oldValue))
-      |    statement.execute()
+      |    database.execute(${update.id}, ""${'"'}
+      |    |UPDATE data
+      |    |SET value = ?1
+      |    |WHERE value ${"$"}{ if (oldValue == null) "IS" else "=" } ?2
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindString(1, if (newValue == null) null else queryWrapper.dataAdapter.valueAdapter.encode(newValue))
+      |        bindString(2, if (oldValue == null) null else queryWrapper.dataAdapter.valueAdapter.encode(oldValue))
+      |    }
       |}
       |""".trimMargin())
   }
@@ -163,13 +162,13 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(data: com.example.Data) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?, ?)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, data.id)
-      |    statement.bindString(2, if (data.value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(data.value!!))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?, ?)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, data.id)
+      |        bindString(2, if (data.value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(data.value!!))
+      |    }
       |}
       |""".trimMargin())
   }
@@ -191,12 +190,12 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(data: com.example.Data) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data (id)
-      |            |VALUES (?)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
-      |    statement.bindLong(1, data.id)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data (id)
+      |    |VALUES (?)
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindLong(1, data.id)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -218,12 +217,12 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(id: kotlin.Long?) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data (id)
-      |            |VALUES (?1)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
-      |    statement.bindLong(1, id)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data (id)
+      |    |VALUES (?1)
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindLong(1, id)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -246,16 +245,16 @@ class MutatorQueryFunctionTest {
     assertThat(generator.function().toString()).isEqualTo("""
       |fun updateData(value: kotlin.collections.List?, id: kotlin.collections.Collection<kotlin.Long>) {
       |    val idIndexes = createArguments(count = id.size, offset = 3)
-      |    val statement = database.prepareStatement(null, ""${'"'}
-      |            |UPDATE data
-      |            |SET value = ?1
-      |            |WHERE id IN ${"$"}idIndexes
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 1 + id.size)
-      |    statement.bindString(1, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |    id.forEachIndexed { index, id ->
-      |            statement.bindLong(index + 3, id)
-      |            }
-      |    statement.execute()
+      |    database.execute(null, ""${'"'}
+      |    |UPDATE data
+      |    |SET value = ?1
+      |    |WHERE id IN ${"$"}idIndexes
+      |    ""${'"'}.trimMargin(), 1 + id.size) {
+      |        bindString(1, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |        id.forEachIndexed { index, id ->
+      |                bindLong(index + 3, id)
+      |                }
+      |    }
       |}
       |""".trimMargin())
   }
@@ -279,15 +278,15 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun updateWithInnerSelect(some_column: kotlin.Long?) {
-      |    val statement = database.prepareStatement(${update.id}, ""${'"'}
-      |            |UPDATE some_table
-      |            |SET some_column = (
-      |            |  SELECT CASE WHEN ?1 IS NULL THEN some_column ELSE ?1 END
-      |            |  FROM some_table
-      |            |)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 1)
-      |    statement.bindLong(1, some_column)
-      |    statement.execute()
+      |    database.execute(${update.id}, ""${'"'}
+      |    |UPDATE some_table
+      |    |SET some_column = (
+      |    |  SELECT CASE WHEN ?1 IS NULL THEN some_column ELSE ?1 END
+      |    |  FROM some_table
+      |    |)
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindLong(1, some_column)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -320,18 +319,18 @@ class MutatorQueryFunctionTest {
       |    c: kotlin.collections.List<kotlin.String>?,
       |    d: kotlin.collections.List<kotlin.String>?
       |) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |UPDATE paymentHistoryConfig
-      |            |SET a = ?1,
-      |            |    b = ?2,
-      |            |    c = ?3,
-      |            |    d = ?4
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 4)
-      |    statement.bindString(1, a)
-      |    statement.bindString(2, b)
-      |    statement.bindBytes(3, if (c == null) null else queryWrapper.paymentHistoryConfigAdapter.cAdapter.encode(c))
-      |    statement.bindBytes(4, if (d == null) null else queryWrapper.paymentHistoryConfigAdapter.dAdapter.encode(d))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |UPDATE paymentHistoryConfig
+      |    |SET a = ?1,
+      |    |    b = ?2,
+      |    |    c = ?3,
+      |    |    d = ?4
+      |    ""${'"'}.trimMargin(), 4) {
+      |        bindString(1, a)
+      |        bindString(2, b)
+      |        bindBytes(3, if (c == null) null else queryWrapper.paymentHistoryConfigAdapter.cAdapter.encode(c))
+      |        bindBytes(4, if (d == null) null else queryWrapper.paymentHistoryConfigAdapter.dAdapter.encode(d))
+      |    }
       |}
       |""".trimMargin())
   }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -27,13 +27,13 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?1, ?2)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, if (id == null) null else id.toLong())
-      |    statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?1, ?2)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, if (id == null) null else id.toLong())
+      |        bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |    }
       |}
       |""".trimMargin())
   }
@@ -69,18 +69,18 @@ class MutatorQueryTypeTest {
       |    deprecated: kotlin.Boolean,
       |    link: kotlin.String
       |) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |UPDATE item
-      |            |SET deprecated = ?3,
-      |            |    link = ?4
-      |            |WHERE packageName = ?1
-      |            |  AND className = ?2
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 4)
-      |    statement.bindLong(3, if (deprecated) 1L else 0L)
-      |    statement.bindString(4, link)
-      |    statement.bindString(1, packageName)
-      |    statement.bindString(2, className)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |UPDATE item
+      |    |SET deprecated = ?3,
+      |    |    link = ?4
+      |    |WHERE packageName = ?1
+      |    |  AND className = ?2
+      |    ""${'"'}.trimMargin(), 4) {
+      |        bindLong(3, if (deprecated) 1L else 0L)
+      |        bindString(4, link)
+      |        bindString(1, packageName)
+      |        bindString(2, className)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -107,13 +107,13 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?1, ?2)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, if (id == null) null else id.toLong())
-      |    statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?1, ?2)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, if (id == null) null else id.toLong())
+      |        bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |    }
       |    notifyQueries(queryWrapper.dataQueries.selectForId)
       |}
       |""".trimMargin())
@@ -143,13 +143,13 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?1, ?2)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, if (id == null) null else id.toLong())
-      |    statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?1, ?2)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, if (id == null) null else id.toLong())
+      |        bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |    }
       |    notifyQueries(queryWrapper.otherDataQueries.selectForId)
       |}
       |""".trimMargin())
@@ -188,13 +188,13 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?1, ?2)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, if (id == null) null else id.toLong())
-      |    statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?1, ?2)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, if (id == null) null else id.toLong())
+      |        bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |    }
       |}
       |""".trimMargin())
   }
@@ -216,13 +216,13 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?1, ?2)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, if (id == null) null else id.toLong())
-      |    statement.bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?1, ?2)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, if (id == null) null else id.toLong())
+      |        bindString(2, if (value == null) null else queryWrapper.dataAdapter.valueAdapter.encode(value))
+      |    }
       |}
       |""".trimMargin())
   }
@@ -255,17 +255,16 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun deleteData() {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |DELETE FROM data
-      |            |WHERE id = 1
-      |            |AND value IN (
-      |            |  SELECT data.value
-      |            |  FROM data
-      |            |  INNER JOIN data AS data2
-      |            |  ON data.id = data2.id
-      |            |)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE, 0)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |DELETE FROM data
+      |    |WHERE id = 1
+      |    |AND value IN (
+      |    |  SELECT data.value
+      |    |  FROM data
+      |    |  INNER JOIN data AS data2
+      |    |  ON data.id = data2.id
+      |    |)
+      |    ""${'"'}.trimMargin(), 0)
       |    notifyQueries(queryWrapper.dataQueries.selectForId)
       |}
       |""".trimMargin())
@@ -288,12 +287,12 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(value: kotlin.Boolean) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data (value)
-      |            |VALUES (?1)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
-      |    statement.bindString(1, if (value) 1L else 0L)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data (value)
+      |    |VALUES (?1)
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindString(1, if (value) 1L else 0L)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -315,12 +314,12 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(value: kotlin.ByteArray) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data (value)
-      |            |VALUES (?1)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
-      |    statement.bindBytes(1, value)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data (value)
+      |    |VALUES (?1)
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindBytes(1, value)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -342,12 +341,12 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |fun insertData(value: kotlin.Double) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data (value)
-      |            |VALUES (?1)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 1)
-      |    statement.bindDouble(1, value)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data (value)
+      |    |VALUES (?1)
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindDouble(1, value)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -389,12 +388,12 @@ class MutatorQueryTypeTest {
       |    deprecated: kotlin.Boolean,
       |    link: kotlin.String
       |) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}INSERT OR FAIL INTO item(packageName, className, deprecated, link) VALUES (?1, ?2, ?3, ?4)""${'"'}, com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 4)
-      |    statement.bindString(1, packageName)
-      |    statement.bindString(2, className)
-      |    statement.bindLong(3, if (deprecated) 1L else 0L)
-      |    statement.bindString(4, link)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}INSERT OR FAIL INTO item(packageName, className, deprecated, link) VALUES (?1, ?2, ?3, ?4)""${'"'}, 4) {
+      |        bindString(1, packageName)
+      |        bindString(2, className)
+      |        bindLong(3, if (deprecated) 1L else 0L)
+      |        bindString(4, link)
+      |    }
       |    notifyQueries(queryWrapper.dataQueries.queryTerm)
       |}
       |""".trimMargin())

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -140,8 +140,7 @@ class SelectQueryFunctionTest {
       |        queryWrapper.dataAdapter.valueAdapter.decode(cursor.getString(1)!!)
       |    )
       |}
-      |
-      """.trimMargin())
+      |""".trimMargin())
   }
 
   @Test fun `integer primary key is always exposed as non-null`() {
@@ -160,8 +159,7 @@ class SelectQueryFunctionTest {
     val query = file.namedQueries.first()
     val generator = SelectQueryGenerator(query)
 
-    assertThat(generator.customResultTypeFunction().toString()).isEqualTo(
-        """
+    assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
       |fun selectData(): com.squareup.sqldelight.Query<kotlin.Long> = com.squareup.sqldelight.Query(${query.id}, selectData, database, ""${'"'}
       ||SELECT *
       ||FROM data
@@ -191,21 +189,21 @@ class SelectQueryFunctionTest {
       |    private val bad: kotlin.collections.Collection<kotlin.Long>,
       |    mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
-      |    override fun createStatement(): com.squareup.sqldelight.db.SqlPreparedStatement {
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor {
       |        val goodIndexes = createArguments(count = good.size, offset = 3)
       |        val badIndexes = createArguments(count = bad.size, offset = good.size + 3)
-      |        val statement = database.prepareStatement(null, ""${'"'}
-      |                |SELECT *
-      |                |FROM data
-      |                |WHERE id IN ${'$'}goodIndexes AND id NOT IN ${'$'}badIndexes
-      |                ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT, good.size + bad.size)
-      |        good.forEachIndexed { index, good ->
-      |                statement.bindLong(index + 3, good)
-      |                }
-      |        bad.forEachIndexed { index, bad ->
-      |                statement.bindLong(index + good.size + 3, bad)
-      |                }
-      |        return statement
+      |        return database.executeQuery(null, ""${'"'}
+      |        |SELECT *
+      |        |FROM data
+      |        |WHERE id IN ${"$"}goodIndexes AND id NOT IN ${"$"}badIndexes
+      |        ""${'"'}.trimMargin(), good.size + bad.size) {
+      |            good.forEachIndexed { index, good ->
+      |                    bindLong(index + 3, good)
+      |                    }
+      |            bad.forEachIndexed { index, bad ->
+      |                    bindLong(index + good.size + 3, bad)
+      |                    }
+      |        }
       |    }
       |}
       |
@@ -282,14 +280,12 @@ class SelectQueryFunctionTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class EquivalentNamesNamed<out T : kotlin.Any>(private val name: kotlin.String, mapper: (com.squareup.sqldelight.db.SqlCursor) -> T) : com.squareup.sqldelight.Query<T>(equivalentNamesNamed, mapper) {
-      |    override fun createStatement(): com.squareup.sqldelight.db.SqlPreparedStatement {
-      |        val statement = database.prepareStatement(${query.id}, ""${'"'}
-      |                |SELECT *
-      |                |FROM person
-      |                |WHERE first_name = ?1 AND last_name = ?1
-      |                ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT, 1)
-      |        statement.bindString(1, name)
-      |        return statement
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = database.executeQuery(${query.id}, ""${'"'}
+      |    |SELECT *
+      |    |FROM person
+      |    |WHERE first_name = ?1 AND last_name = ?1
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindString(1, name)
       |    }
       |}
       |
@@ -568,8 +564,7 @@ class SelectQueryFunctionTest {
       |        cursor.getLong(29)
       |    )
       |}
-      |
-      """.trimMargin())
+      |""".trimMargin())
   }
 
   @Test fun `match expression`() {
@@ -691,8 +686,7 @@ class SelectQueryFunctionTest {
       |        cursor.getLong(3)!!
       |    )
       |}
-      |
-      """.trimMargin())
+      |""".trimMargin())
   }
 
   @Test fun `adapted column in foreign table exposed properly`() {

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -27,14 +27,12 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class SelectForId<out T : kotlin.Any>(private val id: kotlin.Long, mapper: (com.squareup.sqldelight.db.SqlCursor) -> T) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
-      |    override fun createStatement(): com.squareup.sqldelight.db.SqlPreparedStatement {
-      |        val statement = database.prepareStatement(${query.id}, ""${'"'}
-      |                |SELECT *
-      |                |FROM data
-      |                |WHERE id = ?1
-      |                ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT, 1)
-      |        statement.bindLong(1, id)
-      |        return statement
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = database.executeQuery(${query.id}, ""${'"'}
+      |    |SELECT *
+      |    |FROM data
+      |    |WHERE id = ?1
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindLong(1, id)
       |    }
       |}
       |""".trimMargin())
@@ -63,16 +61,14 @@ class SelectQueryTypeTest {
       |    private val id: kotlin.Long,
       |    mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(select, mapper) {
-      |    override fun createStatement(): com.squareup.sqldelight.db.SqlPreparedStatement {
-      |        val statement = database.prepareStatement(${query.id}, ""${'"'}
-      |                |SELECT *
-      |                |FROM data
-      |                |WHERE id = ?2
-      |                |AND value = ?1
-      |                ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT, 2)
-      |        statement.bindLong(2, id)
-      |        statement.bindString(1, value)
-      |        return statement
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = database.executeQuery(${query.id}, ""${'"'}
+      |    |SELECT *
+      |    |FROM data
+      |    |WHERE id = ?2
+      |    |AND value = ?1
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(2, id)
+      |        bindString(1, value)
       |    }
       |}
       |""".trimMargin())
@@ -94,17 +90,17 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class SelectForId<out T : kotlin.Any>(private val id: kotlin.collections.Collection<kotlin.Long>, mapper: (com.squareup.sqldelight.db.SqlCursor) -> T) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
-      |    override fun createStatement(): com.squareup.sqldelight.db.SqlPreparedStatement {
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor {
       |        val idIndexes = createArguments(count = id.size, offset = 2)
-      |        val statement = database.prepareStatement(null, ""${'"'}
-      |                |SELECT *
-      |                |FROM data
-      |                |WHERE id IN ${'$'}idIndexes
-      |                ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT, id.size)
-      |        id.forEachIndexed { index, id ->
-      |                statement.bindLong(index + 2, id)
-      |                }
-      |        return statement
+      |        return database.executeQuery(null, ""${'"'}
+      |        |SELECT *
+      |        |FROM data
+      |        |WHERE id IN ${"$"}idIndexes
+      |        ""${'"'}.trimMargin(), id.size) {
+      |            id.forEachIndexed { index, id ->
+      |                    bindLong(index + 2, id)
+      |                    }
+      |        }
       |    }
       |}
       |""".trimMargin())
@@ -127,10 +123,8 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
        |private inner class Select_news_list<out T : kotlin.Any>(private val userId: kotlin.String?, mapper: (com.squareup.sqldelight.db.SqlCursor) -> T) : com.squareup.sqldelight.Query<T>(select_news_list, mapper) {
-       |    override fun createStatement(): com.squareup.sqldelight.db.SqlPreparedStatement {
-       |        val statement = database.prepareStatement(${query.id}, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId ${"$"}{ if (userId == null) "IS" else "=" } ?1 ORDER BY datetime(creation_time) DESC""${'"'}, com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT, 1)
-       |        statement.bindString(1, userId)
-       |        return statement
+       |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = database.executeQuery(${query.id}, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId ${"$"}{ if (userId == null) "IS" else "=" } ?1 ORDER BY datetime(creation_time) DESC""${'"'}, 1) {
+       |        bindString(1, userId)
        |    }
        |}
        |""".trimMargin())
@@ -163,20 +157,18 @@ class SelectQueryTypeTest {
       |    private val val____: kotlin.String?,
       |    mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
-      |    override fun createStatement(): com.squareup.sqldelight.db.SqlPreparedStatement {
-      |        val statement = database.prepareStatement(${query.id}, ""${'"'}
-      |                |SELECT *
-      |                |FROM data
-      |                |WHERE val ${'$'}{ if (val_ == null) "IS" else "=" } ?1
-      |                |AND val ${'$'}{ if (val__ == null) "IS" else "==" } ?2
-      |                |AND val ${'$'}{ if (val___ == null) "IS NOT" else "<>" } ?3
-      |                |AND val ${'$'}{ if (val____ == null) "IS NOT" else "!=" } ?4
-      |                ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.SELECT, 4)
-      |        statement.bindString(1, val_)
-      |        statement.bindString(2, val__)
-      |        statement.bindString(3, val___)
-      |        statement.bindString(4, val____)
-      |        return statement
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = database.executeQuery(${query.id}, ""${'"'}
+      |    |SELECT *
+      |    |FROM data
+      |    |WHERE val ${"$"}{ if (val_ == null) "IS" else "=" } ?1
+      |    |AND val ${"$"}{ if (val__ == null) "IS" else "==" } ?2
+      |    |AND val ${"$"}{ if (val___ == null) "IS NOT" else "<>" } ?3
+      |    |AND val ${"$"}{ if (val____ == null) "IS NOT" else "!=" } ?4
+      |    ""${'"'}.trimMargin(), 4) {
+      |        bindString(1, val_)
+      |        bindString(2, val__)
+      |        bindString(3, val___)
+      |        bindString(4, val____)
       |    }
       |}
       |""".trimMargin())

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/triggers/TriggerNotificationTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/triggers/TriggerNotificationTest.kt
@@ -43,13 +43,13 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |fun insertData(id: kotlin.Long?, value: kotlin.String?) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |INSERT INTO data
-      |            |VALUES (?1, ?2)
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.INSERT, 2)
-      |    statement.bindLong(1, id)
-      |    statement.bindString(2, value)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |INSERT INTO data
+      |    |VALUES (?1, ?2)
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindLong(1, id)
+      |        bindString(2, value)
+      |    }
       |    notifyQueries(queryWrapper.testQueries.selectData2)
       |}
       |""".trimMargin())
@@ -88,12 +88,12 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |fun deleteData(id: kotlin.Long) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |DELETE FROM data
-      |            |WHERE id = ?1
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.DELETE, 1)
-      |    statement.bindLong(1, id)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |DELETE FROM data
+      |    |WHERE id = ?1
+      |    ""${'"'}.trimMargin(), 1) {
+      |        bindLong(1, id)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -132,14 +132,14 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |fun deleteData(value: kotlin.String?, id: kotlin.Long) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |UPDATE data
-      |            |SET value = ?1
-      |            |WHERE id = ?2
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
-      |    statement.bindString(1, value)
-      |    statement.bindLong(2, id)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |UPDATE data
+      |    |SET value = ?1
+      |    |WHERE id = ?2
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindString(1, value)
+      |        bindLong(2, id)
+      |    }
       |}
       |""".trimMargin())
   }
@@ -178,14 +178,14 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |fun deleteData(value: kotlin.String?, id: kotlin.Long) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |UPDATE data
-      |            |SET value = ?1
-      |            |WHERE id = ?2
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
-      |    statement.bindString(1, value)
-      |    statement.bindLong(2, id)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |UPDATE data
+      |    |SET value = ?1
+      |    |WHERE id = ?2
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindString(1, value)
+      |        bindLong(2, id)
+      |    }
       |    notifyQueries(queryWrapper.testQueries.selectData2)
       |}
       |""".trimMargin())
@@ -225,14 +225,14 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |fun deleteData(value: kotlin.String?, id: kotlin.Long) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |UPDATE data
-      |            |SET value = ?1
-      |            |WHERE id = ?2
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
-      |    statement.bindString(1, value)
-      |    statement.bindLong(2, id)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |UPDATE data
+      |    |SET value = ?1
+      |    |WHERE id = ?2
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindString(1, value)
+      |        bindLong(2, id)
+      |    }
       |    notifyQueries(queryWrapper.testQueries.selectData2)
       |}
       |""".trimMargin())
@@ -272,14 +272,14 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |fun deleteData(value: kotlin.String?, id: kotlin.Long) {
-      |    val statement = database.prepareStatement(${mutator.id}, ""${'"'}
-      |            |UPDATE data
-      |            |SET value = ?1
-      |            |WHERE id = ?2
-      |            ""${'"'}.trimMargin(), com.squareup.sqldelight.db.SqlPreparedStatement.Type.UPDATE, 2)
-      |    statement.bindString(1, value)
-      |    statement.bindLong(2, id)
-      |    statement.execute()
+      |    database.execute(${mutator.id}, ""${'"'}
+      |    |UPDATE data
+      |    |SET value = ?1
+      |    |WHERE id = ?2
+      |    ""${'"'}.trimMargin(), 2) {
+      |        bindString(1, value)
+      |        bindLong(2, id)
+      |    }
       |}
       |""".trimMargin())
   }

--- a/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlDatabase.kt
+++ b/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlDatabase.kt
@@ -25,12 +25,24 @@ interface SqlDatabase : Closeable {
    *   If [identifier] is null, a fresh statement is required.
    * [parameters] is the number of bindable parameters [sql] contains.
    */
-  fun prepareStatement(
+  fun executeQuery(
     identifier: Int?,
     sql: String,
-    type: SqlPreparedStatement.Type,
-    parameters: Int
-  ): SqlPreparedStatement
+    parameters: Int,
+    binders: (SqlPreparedStatement.() -> Unit)? = null
+  ): SqlCursor
+
+  /**
+   * Executes the SQL statement in this [SqlPreparedStatement], which must be an
+   * SQL Data Manipulation Language (DML) statement, such as `INSERT`, `UPDATE` or
+   * `DELETE`; or an SQL statement that returns nothing, such as a DDL statement.
+   */
+  fun execute(
+    identifier: Int?,
+    sql: String,
+    parameters: Int,
+    binders: (SqlPreparedStatement.() -> Unit)? = null
+  )
 
   /**
    * Start a new [Transacter.Transaction] for this connection.

--- a/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlPreparedStatement.kt
+++ b/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlPreparedStatement.kt
@@ -28,17 +28,4 @@ interface SqlPreparedStatement {
   fun bindLong(index: Int, value: Long?)
   fun bindDouble(index: Int, value: Double?)
   fun bindString(index: Int, value: String?)
-
-  fun executeQuery(): SqlCursor
-
-  /**
-   * Executes the SQL statement in this [SqlPreparedStatement], which must be an
-   * SQL Data Manipulation Language (DML) statement, such as `INSERT`, `UPDATE` or
-   * `DELETE`; or an SQL statement that returns nothing, such as a DDL statement.
-   */
-  fun execute()
-
-  enum class Type {
-    INSERT, UPDATE, DELETE, SELECT, EXECUTE
-  }
 }


### PR DESCRIPTION
 - Binds are given a restricted place to run
 - Type no longer needed, apis either do nothing or return a cursor
 - SQL string is lazy, in case a cached statement can be reused

Theres a lot of generated code changes because of this. The only files that should need review are under integration-test: `PlayerQueries` and `QueryWrapper`. Other test changes will be the same.

The other important file to review is `SqlDatabase` as `prepareStatement`'s signature has been changed. 

Driver implementations can be reviewed but they're mostly mechanical, just moving around code to conform to the new `SqlDatabase` api. 