### PR TITLE
Add @Input annotation to packageName + className in SqlDelightTask.

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -34,8 +34,8 @@ open class SqlDelightTask : SourceTask() {
   @get:OutputDirectory var outputDirectory: File? = null
 
   lateinit var sourceFolders: Iterable<File>
-  lateinit var packageName: String
-  lateinit var className: String
+  @Input lateinit var packageName: String
+  @Input lateinit var className: String
 
   @TaskAction
   fun generateSqlDelightFiles() {


### PR DESCRIPTION
Otherwise, the task won't get invalidated if you change them.

There might be more cases where such an annotation is missing. I can dig deeper into that later.