### PR TITLE
Use lineEnd for max line number digit calculation

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
@@ -158,7 +158,7 @@ class SqlDelightEnvironment(
     val result = StringBuilder()
     val tokenizer = StringTokenizer(context.text, "\n", false)
 
-    val maxDigits = (Math.log10(context.lineStart.toDouble()) + 1).toInt()
+    val maxDigits = (Math.log10(context.lineEnd.toDouble()) + 1).toInt()
     for (line in context.lineStart..context.lineEnd) {
       if (!tokenizer.hasMoreTokens()) break
       result.append(("%0${maxDigits}d    %s\n").format(line, tokenizer.nextToken()))


### PR DESCRIPTION
Closes #1153.

I started to write a test but the changes to the test infrastructure became too big. Right now we use a custom annotation implementation to create one-liner errors. I'll try to migrate it to the normal one in a followup.

Here's proof it works in the form of debugger output:
![screen shot 2019-01-15 at 5 18 12 pm](https://user-images.githubusercontent.com/66577/51213743-cbf83a00-18e9-11e9-8ead-af9604138a9e.png)
