### PR TITLE
Update dependencies

### DIFF
--- a/drivers/driver-test/build.gradle
+++ b/drivers/driver-test/build.gradle
@@ -20,8 +20,8 @@ kotlin {
   }
 
   targets {
-    fromPreset(presets.jvm, 'jvm')
-    fromPreset(presets.iosX64, 'iosX64')
-    fromPreset(presets.iosArm64, 'iosArm64')
+    targetFromPreset(presets.jvm, 'jvm')
+    targetFromPreset(presets.iosX64, 'iosX64')
+    targetFromPreset(presets.iosArm64, 'iosArm64')
   }
 }

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/DriverTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/DriverTest.kt
@@ -17,15 +17,15 @@ abstract class DriverTest {
   protected val schema = object : Schema {
     override val version: Int = 1
 
-    override fun create(db: SqlDriver) {
-      db.execute(0, """
+    override fun create(driver: SqlDriver) {
+      driver.execute(0, """
               |CREATE TABLE test (
               |  id INTEGER PRIMARY KEY,
               |  value TEXT
               |);
             """.trimMargin(), 0
       )
-      db.execute(1, """
+      driver.execute(1, """
               |CREATE TABLE nullability_test (
               |  id INTEGER PRIMARY KEY,
               |  integer_value INTEGER,
@@ -38,7 +38,7 @@ abstract class DriverTest {
     }
 
     override fun migrate(
-      db: SqlDriver,
+      driver: SqlDriver,
       oldVersion: Int,
       newVersion: Int
     ) {

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
@@ -28,8 +28,8 @@ abstract class QueryTest {
         schema = object : SqlDriver.Schema {
           override val version: Int = 1
 
-          override fun create(db: SqlDriver) {
-            db.execute(null, """
+          override fun create(driver: SqlDriver) {
+            driver.execute(null, """
               CREATE TABLE test (
                 id INTEGER NOT NULL PRIMARY KEY,
                 value TEXT NOT NULL
@@ -39,7 +39,7 @@ abstract class QueryTest {
           }
 
           override fun migrate(
-            db: SqlDriver,
+            driver: SqlDriver,
             oldVersion: Int,
             newVersion: Int
           ) {

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
@@ -19,9 +19,9 @@ abstract class TransacterTest {
   @BeforeTest fun setup() {
     val driver = setupDatabase(object : Schema {
       override val version = 1
-      override fun create(db: SqlDriver) {}
+      override fun create(driver: SqlDriver) {}
       override fun migrate(
-        db: SqlDriver,
+        driver: SqlDriver,
         oldVersion: Int,
         newVersion: Int
       ) {

--- a/drivers/ios-driver/build.gradle
+++ b/drivers/ios-driver/build.gradle
@@ -28,8 +28,8 @@ kotlin {
   }
 
   targets {
-    fromPreset(presets.iosX64, 'iosX64')
-    fromPreset(presets.iosArm64, 'iosArm64')
+    targetFromPreset(presets.iosX64, 'iosX64')
+    targetFromPreset(presets.iosArm64, 'iosArm64')
   }
 
   configure([targets.iosX64, targets.iosArm64]) {

--- a/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosDriverTest.kt
+++ b/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosDriverTest.kt
@@ -3,45 +3,11 @@ package com.squareup.sqldelight.drivers.ios
 import co.touchlab.sqliter.DatabaseFileContext.deleteDatabase
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.driver.test.DriverTest
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class IosDriverTest : DriverTest() {
   override fun setupDatabase(schema: SqlDriver.Schema): SqlDriver {
     val name = "testdb"
     deleteDatabase(name)
     return NativeSqliteDriver(schema, name)
-  }
-
-  // TODO: https://github.com/JetBrains/kotlin-native/issues/2328
-
-  @BeforeTest fun setup2() {
-    super.setup()
-  }
-
-  @AfterTest fun tearDown2() {
-    super.tearDown()
-  }
-
-  // Sanity check of the driver.
-  @Test fun basicTest() {
-    val cursor = driver.executeQuery(0, "SELECT 1", 0)
-    cursor.next()
-    assertEquals(1, cursor.getLong(0))
-    cursor.close()
-  }
-
-  @Test fun `insert can run multiple times2`() {
-    super.`insert can run multiple times`()
-  }
-
-  @Test fun `query can run multiple times2`() {
-    super.`query can run multiple times`()
-  }
-
-  @Test fun `SqlResultSet getters return null if the column values are NULL2`() {
-    super.`SqlResultSet getters return null if the column values are NULL`()
   }
 }

--- a/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosQueryTest.kt
+++ b/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosQueryTest.kt
@@ -3,69 +3,11 @@ package com.squareup.sqldelight.drivers.ios
 import co.touchlab.sqliter.DatabaseFileContext
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.driver.test.QueryTest
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
 
 class IosQueryTest: QueryTest() {
   override fun setupDatabase(schema: SqlDriver.Schema): SqlDriver {
     val name = "testdb"
     DatabaseFileContext.deleteDatabase(name)
     return NativeSqliteDriver(schema, name)
-  }
-
-  // TODO: https://github.com/JetBrains/kotlin-native/issues/2328
-
-  @BeforeTest fun setup2() {
-    super.setup()
-  }
-
-  @AfterTest fun tearDown2() {
-    super.tearDown()
-  }
-
-
-  @Test fun executeAsOne2() {
-    super.executeAsOne()
-  }
-
-  @Test fun executeAsOneTwoTimes2() {
-    super.executeAsOneTwoTimes()
-  }
-
-  @Test fun executeAsOneThrowsNpeForNoRows2() {
-    super.executeAsOneThrowsNpeForNoRows()
-  }
-
-  @Test fun executeAsOneThrowsIllegalStateExceptionForManyRows2() {
-    super.executeAsOneThrowsIllegalStateExceptionForManyRows()
-  }
-
-  @Test fun executeAsOneOrNull2() {
-    super.executeAsOneOrNull()
-  }
-
-  @Test fun executeAsOneOrNullReturnsNullForNoRows2() {
-    super.executeAsOneOrNullReturnsNullForNoRows()
-  }
-
-  @Test fun executeAsOneOrNullThrowsIllegalStateExceptionForManyRows2() {
-    super.executeAsOneOrNullThrowsIllegalStateExceptionForManyRows()
-  }
-
-  @Test fun executeAsList2() {
-    super.executeAsList()
-  }
-
-  @Test fun executeAsListForNoRows2() {
-    super.executeAsListForNoRows()
-  }
-
-  @Test fun notifyDataChangedNotifiesListeners2() {
-    super.notifyDataChangedNotifiesListeners()
-  }
-
-  @Test fun removeListenerActuallyRemovesListener2() {
-    super.removeListenerActuallyRemovesListener()
   }
 }

--- a/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosTransacterTest.kt
+++ b/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/IosTransacterTest.kt
@@ -3,76 +3,11 @@ package com.squareup.sqldelight.drivers.ios
 import co.touchlab.sqliter.DatabaseFileContext.deleteDatabase
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.driver.test.TransacterTest
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Ignore
-import kotlin.test.Test
-import kotlin.native.concurrent.freeze
 
 class IosTransacterTest: TransacterTest() {
   override fun setupDatabase(schema: SqlDriver.Schema): SqlDriver {
     val name = "testdb"
     deleteDatabase(name)
     return NativeSqliteDriver(schema, name)
-  }
-
-  // TODO: https://github.com/JetBrains/kotlin-native/issues/2328
-
-  @BeforeTest fun setup2() {
-    super.setup()
-    transacter.freeze()
-  }
-
-  @AfterTest fun tearDown2() {
-    super.teardown()
-  }
-
-  @Test fun `afterCommit runs after transaction commits2`() {
-    super.`afterCommit runs after transaction commits`()
-  }
-
-  @Test fun `afterCommit does not run after transaction rollbacks2`() {
-    super.`afterCommit does not run after transaction rollbacks`()
-  }
-
-  @Test fun `afterCommit runs after enclosing transaction commits2`() {
-    super.`afterCommit runs after enclosing transaction commits`()
-  }
-
-  @Test fun `afterCommit does not run in nested transaction when enclosing rolls back2`() {
-    super.`afterCommit does not run in nested transaction when enclosing rolls back`()
-  }
-
-  @Test fun `afterCommit does not run in nested transaction when nested rolls back2`() {
-    super.`afterCommit does not run in nested transaction when nested rolls back`()
-  }
-
-  @Test fun `afterRollback no-ops if the transaction never rolls back2`() {
-    super.`afterRollback no-ops if the transaction never rolls back`()
-  }
-
-  @Test fun `afterRollback runs after a rollback occurs2`() {
-    super.`afterRollback runs after a rollback occurs`()
-  }
-
-  @Test fun `afterRollback runs after an inner transaction rolls back2`() {
-    super.`afterRollback runs after an inner transaction rolls back`()
-  }
-
-  @Test fun `afterRollback runs in an inner transaction when the outer transaction rolls back2`() {
-    super.`afterRollback runs in an inner transaction when the outer transaction rolls back`()
-  }
-
-  @Test fun `transactions close themselves out properly2`() {
-    super.`transactions close themselves out properly`()
-  }
-
-  @Test fun `setting no enclosing fails if there is a currently running transaction2`() {
-    super.`setting no enclosing fails if there is a currently running transaction`()
-  }
-
-  @Ignore @Test
-  fun `An exception thrown in postRollback function is combined with the exception in the main body2`() {
-    super.`An exception thrown in postRollback function is combined with the exception in the main body`()
   }
 }

--- a/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/LazyDriverBaseTest.kt
+++ b/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/LazyDriverBaseTest.kt
@@ -39,14 +39,14 @@ abstract class LazyDriverBaseTest {
     return object : SqlDriver.Schema {
       override val version: Int = 1
 
-      override fun create(db: SqlDriver) {
-        db.execute(20, """
+      override fun create(driver: SqlDriver) {
+        driver.execute(20, """
                   |CREATE TABLE test (
                   |  id INTEGER PRIMARY KEY,
                   |  value TEXT
                   |);
                 """.trimMargin(), 0)
-        db.execute(30, """
+        driver.execute(30, """
                   |CREATE TABLE nullability_test (
                   |  id INTEGER PRIMARY KEY,
                   |  integer_value INTEGER,
@@ -58,7 +58,7 @@ abstract class LazyDriverBaseTest {
       }
 
       override fun migrate(
-        db: SqlDriver,
+        driver: SqlDriver,
         oldVersion: Int,
         newVersion: Int
       ) {

--- a/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/NativeSqliteDriverTest.kt
+++ b/drivers/ios-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/ios/NativeSqliteDriverTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
+import kotlin.test.assertFails
 
 //Run tests with WAL db
 class NativeSqliteDriverTestWAL : NativeSqliteDriverTest() {
@@ -92,13 +93,15 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
 
   @Test
   fun `failing transaction clears lock`() {
-    transacter.transaction {
-      driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
-        bindLong(1, 1)
-        bindString(2, "asdf")
-      }
+    assertFails {
+      transacter.transaction {
+        driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+          bindLong(1, 1)
+          bindString(2, "asdf")
+        }
 
-      throw IllegalStateException("Fail")
+        throw IllegalStateException("Fail")
+      }
     }
 
     transacter.transaction {
@@ -120,9 +123,11 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
   @Test
   fun `bad bind doens't taint future binding`() {
     transacter.transaction {
-      driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
-        bindLong(1, 1)
-        bindString(3, "asdf")
+      assertFails {
+        driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+          bindLong(1, 1)
+          bindString(3, "asdf")
+        }
       }
     }
 
@@ -395,8 +400,8 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
 
     transacter.transaction {
       driver.execute(null, "insert into test(id, value)values(?, ?)", 2) {
-        bindLong(1, 22L)
-        bindString(2, "Hey 22")
+        bindLong(1, 23L)
+        bindString(2, "Hey 23")
       }
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 ext.versions = [
-    kotlin: '1.3.10',
+    kotlin: '1.3.20',
     compileSdk: 28,
-    idea: '2018.2.2',
+    idea: '2018.2.3',
     dokka: '0.9.17',
     androidxSqlite: '2.0.0',
     minSdk: 14,
@@ -9,9 +9,9 @@ ext.versions = [
     schemaCrawler: '14.16.04.01-java7',
     sqldelight: '1.0.0',
     moshi: '1.8.0',
-    stately: '0.5.1',
-    sqliter: '0.5.10',
-    testhelp: '0.1.0',
+    stately: '0.5.2',
+    sqliter: '0.5.11',
+    testhelp: '0.1.2',
     paging: '2.0.0',
 ]
 
@@ -22,7 +22,7 @@ ext.deps = [
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
         download: "de.undercouch:gradle-download-task:3.4.2",
         intellij: "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.1",
-        grammarKit: "com.github.hurricup:gradle-grammar-kit-plugin:${versions.idea}",
+        grammarKit: "com.github.hurricup:gradle-grammar-kit-plugin:2018.3",
     ],
     kotlin: [
         stdlib: [

--- a/sample/common/build.gradle
+++ b/sample/common/build.gradle
@@ -23,6 +23,6 @@ kotlin {
     }
   }
   targets {
-    fromPreset(presets.jvm, 'jvm')
+    targetFromPreset(presets.jvm, 'jvm')
   }
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
@@ -159,11 +159,15 @@ open class SqlDelightPlugin : Plugin<Project> {
               compilationUnit.extraOpts("-linker-options", "-lsqlite3")
               project.tasks.named(compilationUnit.compileAllTaskName).configure { it.dependsOn(task) }
               project.tasks.named(compilationUnit.compileKotlinTaskName).configure { it.dependsOn(task) }
-              project.tasks.named(compilationUnit.linkAllTaskName).configure { it.dependsOn(task) }
               NativeOutputKind.values().forEach { kind ->
                 NativeBuildType.values().forEach { buildType ->
                   compilationUnit.findLinkTask(kind, buildType)?.dependsOn(task)
                 }
+              }
+
+              // Kotlin 1.3.20 DSL
+              compilationUnit.target.binaries.forEach {
+                it.linkTask.dependsOn(task)
               }
             } else {
               project.tasks.named(compilationUnit.compileKotlinTaskName)

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
@@ -41,7 +41,7 @@ sqldelight {
 
 kotlin {
   targets {
-    fromPreset(presets.android, 'android')
+    targetFromPreset(presets.android, 'android')
   }
 
   sourceSets {

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
@@ -24,7 +24,7 @@ kotlin {
   targets {
     def buildForDevice = project.findProperty("device")?.toBoolean() ?: false
     def iosPreset = (buildForDevice) ? presets.iosArm64 : presets.iosX64
-    fromPreset(iosPreset, 'ios') {
+    targetFromPreset(iosPreset, 'ios') {
       compilations.main.outputKinds('FRAMEWORK')
     }
   }

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+  id 'org.jetbrains.kotlin.multiplatform'
+  id 'com.squareup.sqldelight'
+}
+
+apply from: '../../../../gradle/dependencies.gradle'
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+  }
+  mavenCentral()
+}
+
+sqldelight {
+  packageName = "com.sample"
+}
+
+kotlin {
+  iosX64('ios') {
+    binaries {
+      framework()
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/settings.gradle
@@ -1,0 +1,1 @@
+enableFeaturePreview('GRADLE_METADATA')

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/src/main/sqldelight/com/sample/Test.sq
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/src/main/sqldelight/com/sample/Test.sq
@@ -1,0 +1,20 @@
+CREATE TABLE test (
+  value2 TEXT NOT NULL,
+  value TEXT NOT NULL
+);
+
+CREATE INDEX testIndex ON test(value);
+
+CREATE TRIGGER testTrigger
+AFTER DELETE ON test
+BEGIN
+INSERT INTO test VALUES ("1", "2");
+END;
+
+CREATE VIEW testView AS
+SELECT *
+FROM test;
+
+select:
+SELECT *
+FROM test;

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp/build.gradle
@@ -35,9 +35,9 @@ kotlin {
     }
   }
   targets {
-    fromPreset(presets.jvm, 'jvm')
-    fromPreset(presets.js, 'js')
-    fromPreset(presets.iosArm64, 'iosArm64')
-    fromPreset(presets.iosX64, 'iosX64')
+    targetFromPreset(presets.jvm, 'jvm')
+    targetFromPreset(presets.js, 'js')
+    targetFromPreset(presets.iosArm64, 'iosArm64')
+    targetFromPreset(presets.iosX64, 'iosX64')
   }
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
@@ -115,14 +115,32 @@ class PluginTest {
 
     buildDir.delete()
     var result = runner
-        .withArguments("clean", "linkIosArm64", "--stacktrace")
+        .withArguments("clean", "compileKotlinIosArm64", "--stacktrace")
         .build()
     assertThat(result.output).contains("generateSqlDelightInterface")
     assertThat(buildDir.exists()).isTrue()
 
     buildDir.delete()
     result = runner
-        .withArguments("clean", "linkIosX64", "--stacktrace")
+        .withArguments("clean", "compileKotlinIosX64", "--stacktrace")
+        .build()
+    assertThat(result.output).contains("generateSqlDelightInterface")
+    assertThat(buildDir.exists()).isTrue()
+  }
+
+  @Test
+  @Category(IosTest::class)
+  fun `The generate task is a dependency of multiplatform ios target with 1-3-20 DSL`() {
+    val fixtureRoot = File("src/test/kotlin-mpp-1.3.20")
+    val runner = GradleRunner.create()
+        .withProjectDir(fixtureRoot)
+        .withPluginClasspath()
+
+    val buildDir = File(fixtureRoot, "build/sqldelight")
+
+    buildDir.delete()
+    val result = runner
+        .withArguments("clean", "compileKotlinIos", "--stacktrace")
         .build()
     assertThat(result.output).contains("generateSqlDelightInterface")
     assertThat(buildDir.exists()).isTrue()

--- a/sqldelight-runtime/build.gradle
+++ b/sqldelight-runtime/build.gradle
@@ -48,10 +48,10 @@ kotlin {
   }
 
   targets {
-    fromPreset(presets.jvm, 'jvm')
-    fromPreset(presets.js, 'js')
-    fromPreset(presets.iosX64, 'iosX64')
-    fromPreset(presets.iosArm64, 'iosArm64')
+    targetFromPreset(presets.jvm, 'jvm')
+    targetFromPreset(presets.js, 'js')
+    targetFromPreset(presets.iosX64, 'iosX64')
+    targetFromPreset(presets.iosArm64, 'iosArm64')
   }
 
   configure([targets.iosX64, targets.iosArm64]) {

--- a/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
+++ b/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
@@ -120,6 +120,10 @@ abstract class Transacter(private val driver: SqlDriver) {
         enclosing.postRollbackHooks.addAll(transaction.postRollbackHooks)
         enclosing.queriesToUpdate.addAll(transaction.queriesToUpdate)
       }
+
+      if (thrownException != null && thrownException !is RollbackException) {
+        throw thrownException
+      }
     }
   }
 

--- a/sqldelight-runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Atomics.kt
+++ b/sqldelight-runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Atomics.kt
@@ -2,13 +2,14 @@ package com.squareup.sqldelight.internal
 
 import co.touchlab.stately.concurrency.value
 import kotlin.native.concurrent.AtomicReference
+import kotlin.native.concurrent.freeze
 
 actual class Atomic<V> actual constructor(value: V) {
   private val atomicRef = AtomicReference(value)
 
   actual fun get() = atomicRef.value
   actual fun set(value: V) {
-    atomicRef.value = value
+    atomicRef.value = value.freeze()
   }
 }
 


### PR DESCRIPTION
 - Kotlin 1.3.10 -> 1.3.20
   - Includes new Kotlin/Native
 - SQLiter 0.5.11 -> 0.5.12
 - Stately 0.5.1 -> 0.5.2
 - testhelp 0.1.0 -> 0.1.2
 - Fixed a bug where crashes in a transaction were swallowed

Closes #1191 

cc @kpgalligan 