### PR TITLE
add Internal annotation to remove build warning

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
@@ -5,6 +5,7 @@ import com.squareup.sqldelight.core.SqlDelightEnvironment
 import com.squareup.sqldelight.core.lang.SqlDelightFile
 import com.squareup.sqldelight.core.lang.util.forInitializationStatements
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
@@ -17,7 +18,7 @@ open class GenerateSchemaTask : SourceTask() {
 
   @get:OutputDirectory var outputDirectory: File? = null
 
-  lateinit var sourceFolders: Iterable<File>
+  @Internal lateinit var sourceFolders: Iterable<File>
 
   @TaskAction
   fun generateSchemaFile() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -22,6 +22,7 @@ import com.squareup.sqldelight.core.SqlDelightException
 import org.gradle.api.logging.LogLevel.ERROR
 import org.gradle.api.logging.LogLevel.INFO
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
@@ -33,7 +34,7 @@ open class SqlDelightTask : SourceTask() {
 
   @get:OutputDirectory var outputDirectory: File? = null
 
-  lateinit var sourceFolders: Iterable<File>
+  @Internal lateinit var sourceFolders: Iterable<File>
   @Input lateinit var packageName: String
   @Input lateinit var className: String
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
@@ -9,6 +9,7 @@ import com.squareup.sqlite.migrations.CatalogDatabase
 import com.squareup.sqlite.migrations.DatabaseFilesCollector
 import com.squareup.sqlite.migrations.ObjectDifferDatabaseComparator
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -17,7 +18,7 @@ open class VerifyMigrationTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input fun pluginVersion() = VERSION
 
-  lateinit var sourceFolders: Iterable<File>
+  @Internal lateinit var sourceFolders: Iterable<File>
 
   private val environment by lazy {
     SqlDelightEnvironment(sourceFolders = sourceFolders.filter { it.exists() })


### PR DESCRIPTION
`@Internal` annotation can remove following warnings.

```
> Task :sqldelight-gradle-plugin:validateTaskProperties
Task property validation finished with warnings:
  - Warning: Task type 'com.squareup.sqldelight.gradle.GenerateSchemaTask': property 'sourceFolders' is not annotated with an input or output annotation.
  - Warning: Task type 'com.squareup.sqldelight.gradle.SqlDelightTask': property 'sourceFolders' is not annotated with an input or output annotation.
  - Warning: Task type 'com.squareup.sqldelight.gradle.VerifyMigrationTask': property 'sourceFolders' is not annotated with an input or output annotation.
```