### PR TITLE
README suggestion of .sq files in src/main/sqldelight

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ SQLDelight generates typesafe APIs from your SQL statements. It compile-time ver
 Example
 -------
 
-To use SQLDelight, apply the [gradle plugin](https://github.com/square/sqldelight#gradle) and put your SQL statements in a `.sq` file, like
-`src/main/sqldelight/com/example/HockeyPlayer.sq`. Typically the first statement creates a table.
+To use SQLDelight, apply the [gradle plugin](https://github.com/square/sqldelight#gradle) and put your SQL statements in a `.sq` file in `src/main/sqldelight`.  Typically the first statement in the SQL file creates a table.
 
 ```sql
+-- src/main/sqldelight/com/example/sqldelight/hockey/data/Player.sq
+
 CREATE TABLE hockeyPlayer (
   player_number INTEGER NOT NULL,
   full_name TEXT NOT NULL


### PR DESCRIPTION
As a first time user of the library I was putting my `.sq` files in `src/main/java/com...` and didn't understand why codegen wasn't working.  There was a small note in the current README showing an example file path which included `src/main/sqldelight`, but it wasn't clearly called out as a requirement as a first time user, without custom gradle plugin configuration.

I'm submitting this change in hopes that it will improve the first time experience of using SqlDelight and avoid my 30 minutes of trying to figure out why it wasn't generating sources: https://twitter.com/HandstandSam/status/1093513648885116928

I finally figured it out after finding @AlecStrong's blog post and seeing it as a SQL comment in his examples: https://medium.com/square-corner-blog/announcing-sqldelight-1-0-d482aa408f64