### PR TITLE
Use lazy delegate when resolving writable database in AndroidSqliteDriver

### DIFF
--- a/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
@@ -22,7 +22,9 @@ class AndroidSqliteDriver private constructor(
   private val cacheSize: Int
 ) : SqlDriver {
   private val transactions = ThreadLocal<Transacter.Transaction>()
-  private val database = openHelper?.writableDatabase ?: database!!
+  private val database by lazy {
+    openHelper?.writableDatabase ?: database!!
+  }
 
   constructor(
     openHelper: SupportSQLiteOpenHelper


### PR DESCRIPTION
According to the documentation on SupportSQLiteOpenHelper, getWritableDatabase should not be called on the main thread.

Is there a reason why the writableDatabase is accessed at the creation of AndroidSqliteDriver? To me it looks like the database property is only used in queries and transactions and can therefore be a lazy property.