### PR TITLE
Ensure un-cached statements are closed after use

### DIFF
--- a/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
@@ -3,6 +3,7 @@ package com.squareup.sqldelight.android
 import android.content.Context
 import android.database.Cursor
 import android.util.LruCache
+import androidx.annotation.VisibleForTesting
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.SupportSQLiteProgram
@@ -160,7 +161,7 @@ class AndroidSqliteDriver private constructor(
   }
 }
 
-private interface AndroidStatement : SqlPreparedStatement {
+@VisibleForTesting interface AndroidStatement : SqlPreparedStatement {
   fun execute()
   fun executeQuery(): SqlCursor
   fun close()

--- a/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
@@ -3,7 +3,6 @@ package com.squareup.sqldelight.android
 import android.content.Context
 import android.database.Cursor
 import android.util.LruCache
-import androidx.annotation.VisibleForTesting
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.SupportSQLiteProgram
@@ -161,7 +160,7 @@ class AndroidSqliteDriver private constructor(
   }
 }
 
-@VisibleForTesting interface AndroidStatement : SqlPreparedStatement {
+internal interface AndroidStatement : SqlPreparedStatement {
   fun execute()
   fun executeQuery(): SqlCursor
   fun close()

--- a/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
@@ -113,7 +113,11 @@ class AndroidSqliteDriver private constructor(
       if (binders != null) { statement.binders() }
       return statement.result()
     } finally {
-      if (identifier != null) statements.put(identifier, statement)?.close()
+      if (identifier != null) {
+        statements.put(identifier, statement)?.close()
+      } else {
+        statement.close()
+      }
     }
   }
 

--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
@@ -44,4 +44,15 @@ class AndroidDriverTest : DriverTest() {
       assertNotSame(bindable, this)
     }
   }
+
+  @Test(expected = IllegalStateException::class)
+  fun `uncached statement is closed`() {
+    val driver = AndroidSqliteDriver(schema, RuntimeEnvironment.application, cacheSize = 1)
+    lateinit var bindable: AndroidStatement
+    driver.execute(null, "SELECT * FROM test", 0) {
+      bindable = this as AndroidStatement
+    }
+    // this should throw an exception; the statement will already be closed
+    bindable.execute()
+  }
 }

--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
@@ -45,14 +45,19 @@ class AndroidDriverTest : DriverTest() {
     }
   }
 
-  @Test(expected = IllegalStateException::class)
+  @Test
   fun `uncached statement is closed`() {
     val driver = AndroidSqliteDriver(schema, RuntimeEnvironment.application, cacheSize = 1)
     lateinit var bindable: AndroidStatement
     driver.execute(null, "SELECT * FROM test", 0) {
       bindable = this as AndroidStatement
     }
-    // this should throw an exception; the statement will already be closed
-    bindable.execute()
+
+    try {
+      bindable.execute()
+      throw AssertionError("Expected an IllegalStateException (attempt to re-open an already-closed object)")
+    } catch (ignored: IllegalStateException) {
+
+    }
   }
 }


### PR DESCRIPTION
I'm not sure if we expect these statements to be closed sometime in the future when the statements are collected or something, but it seems like we should be closing these as well.