### PR TITLE
fix multiplatform instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ sqldelight {
 }
 ```
 
-Continue to put `.sq` files in the `src/main/kotlin` directory, and then `expect` a `SqlDriver` to be provided by individual platforms when creating the `Database`.
+Put `.sq` files in the `src/commonMain/sqldelight` directory, and then `expect` a `SqlDriver` to be provided by individual platforms when creating the `Database`. Migration files should also be in the same `src/commonMain/sqldelight` directory.
 
 Multiplatform **requires the gradle metadata feature**, which you need to enable via the `settings.gradle` file in the project root:
 


### PR DESCRIPTION
Instruction says `.sq` files should be inside `src/main/kotlin`, but it's actually `src/commonMain/sqldelight`.

I think this misinstruction is confusing some users trying to use the library in Multiplatform setup.