### PR TITLE
Adds support for configuration in Kotlin script build files.

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightExtension.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightExtension.kt
@@ -61,8 +61,6 @@ open class SqlDelightExtension {
    * }
    */
   fun database(name: String, config: SqlDelightDatabase.() -> Unit) {
-    configuringDatabase?.methodMissing(name, args)?.let { return it }
-
     val database = SqlDelightDatabase(project, name = name).apply(config)
 
     if (databases.any { it.name == database.name }) {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightExtension.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightExtension.kt
@@ -50,6 +50,28 @@ open class SqlDelightExtension {
     return Unit
   }
 
+  /**
+   * Supports configuration in Kotlin script build files.
+   *
+   * sqldelight {
+   *   "MyDatabase" {
+   *     packageName = "com.example"
+   *     sourceSet = files("src/main/sqldelight")
+   *   }
+   * }
+   */
+  operator fun String.invoke(config: SqlDelightDatabase.() -> Unit) {
+    configuringDatabase?.methodMissing(this, args)?.let { return it }
+
+    val database = SqlDelightDatabase(project, name = this).apply(config)
+
+    if (databases.any { it.name == database.name }) {
+      throw IllegalStateException("There is already a database defined for ${database.name}")
+    }
+
+    databases.add(database)
+  }
+
   companion object {
     private fun newDsl(): Nothing = throw GradleException("""
       |Format of specifying databases has changed from:

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightExtension.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightExtension.kt
@@ -54,16 +54,16 @@ open class SqlDelightExtension {
    * Supports configuration in Kotlin script build files.
    *
    * sqldelight {
-   *   "MyDatabase" {
+   *   database("MyDatabase") {
    *     packageName = "com.example"
    *     sourceSet = files("src/main/sqldelight")
    *   }
    * }
    */
-  operator fun String.invoke(config: SqlDelightDatabase.() -> Unit) {
-    configuringDatabase?.methodMissing(this, args)?.let { return it }
+  fun database(name: String, config: SqlDelightDatabase.() -> Unit) {
+    configuringDatabase?.methodMissing(name, args)?.let { return it }
 
-    val database = SqlDelightDatabase(project, name = this).apply(config)
+    val database = SqlDelightDatabase(project, name = name).apply(config)
 
     if (databases.any { it.name == database.name }) {
       throw IllegalStateException("There is already a database defined for ${database.name}")


### PR DESCRIPTION
I'm working to implement SqlDelight in a build that uses `build.gradle.kts` files and struggled with the database configuration, since it relies on some dynamic features of Groovy (AFAIK).  I've been able to get my build working using the following extension function:

```kotlin
sqldelight {

  operator fun String.invoke(config: SqlDelightDatabase.() -> Unit) {
    methodMissing(this, arrayOf(object : Closure<SqlDelightDatabase>(this) {
      fun doCall(database: SqlDelightDatabase) {
        database.config()
      }
    }))
  }

  "MyDatabase" {
    packageName = "com.example.db"
  }
}
```

This makes for a pretty nice Kotlin DSL that mimics the groovy one pretty closely, but is also a pain and involved unnecessary wrapping when Kotlin's `apply` would work nicely.

I'm running short on time, so this is a bit untested, since it's kind of a pain to test :/ Feel free to close or request updates.