### PR TITLE
Map old maven plugin tasks to maven-publish tasks

### DIFF
--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -60,3 +60,9 @@ kotlin {
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-mpp-push.gradle"
+
+afterEvaluate {
+  tasks.create('install').dependsOn('publishToMavenLocal')
+  tasks.create('installLocally').dependsOn('publishAllPublicationsToTestRepository')
+  tasks.create('uploadArchives').dependsOn('publishAllPublicationsToMavenRepository')
+}


### PR DESCRIPTION
This ensures the artifacts will be included in the snapshot and release process.