### PR TITLE
Don't link sqlite by default in ios driver; allow linking opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,17 +332,6 @@ Supported Dialects
 #### SQLite
 Full support of dialect including views, triggers, indexes, FTS tables, etc. If features are missing please file an issue!
 
-##### Linking SQLite
-
-By default, SQLDelight links system SQLite into your SQLDelight targets via `-lsqlite3` (for native targets). If you prefer to link a different SQLite, you can control this behavior using the `linkSqlite` flag in the gradle plugin:
-
-```groovy
-sqldelight {
-  linkSqlite = false
-  packageName = "com.example.hockey"
-}
-```
-
 IntelliJ Plugin
 ---------------
 
@@ -387,6 +376,10 @@ sqldelight {
     // Optionally specify schema dependencies on other gradle projects
     dependency project(':OtherProject')
   }
+  
+  // For native targets, chose wether sqlite should be automatically linked.
+  // Defaults to true.
+  linkSqlite = false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,18 @@ Multiplatform **requires the gradle metadata feature**, which you need to enable
 enableFeaturePreview('GRADLE_METADATA')
 ```
 
+### Linking SQLite
+
+By default, SQLDelight links system SQLite into your SQLDelight targets via `-lsqlite3`. If you prefer to link a different SQLite, you can control this behavior using the `linkSqlite` flag in the gradle plugin:
+
+```groovy
+sqldelight {
+  linkSqlite = false
+  packageName = "com.example.hockey"
+}
+```
+
+
 Android Paging
 --------------
 

--- a/README.md
+++ b/README.md
@@ -296,18 +296,6 @@ Multiplatform **requires the gradle metadata feature**, which you need to enable
 enableFeaturePreview('GRADLE_METADATA')
 ```
 
-### Linking SQLite
-
-By default, SQLDelight links system SQLite into your SQLDelight targets via `-lsqlite3`. If you prefer to link a different SQLite, you can control this behavior using the `linkSqlite` flag in the gradle plugin:
-
-```groovy
-sqldelight {
-  linkSqlite = false
-  packageName = "com.example.hockey"
-}
-```
-
-
 Android Paging
 --------------
 
@@ -343,6 +331,17 @@ Supported Dialects
 
 #### SQLite
 Full support of dialect including views, triggers, indexes, FTS tables, etc. If features are missing please file an issue!
+
+##### Linking SQLite
+
+By default, SQLDelight links system SQLite into your SQLDelight targets via `-lsqlite3` (for native targets). If you prefer to link a different SQLite, you can control this behavior using the `linkSqlite` flag in the gradle plugin:
+
+```groovy
+sqldelight {
+  linkSqlite = false
+  packageName = "com.example.hockey"
+}
+```
 
 IntelliJ Plugin
 ---------------

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ apply from: "$rootDir/gradle/dependencies.gradle"
 
 allprojects {
   repositories {
-    mavenLocal()
     mavenCentral()
     google()
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ apply from: "$rootDir/gradle/dependencies.gradle"
 
 allprojects {
   repositories {
+    mavenLocal()
     mavenCentral()
     google()
     jcenter()

--- a/drivers/ios-driver/build.gradle
+++ b/drivers/ios-driver/build.gradle
@@ -36,8 +36,8 @@ kotlin {
   configure([targets.iosX64, targets.iosArm32, targets.iosArm64]) {
     compilations.main.source(sourceSets.nativeMain)
     compilations.test.source(sourceSets.nativeTest)
-    compilations.each {
-      it.extraOpts("-linker-options", "-lsqlite3")
+    compilations.test {
+      extraOpts("-linker-options", "-lsqlite3")
     }
   }
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightExtension.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightExtension.kt
@@ -12,6 +12,8 @@ open class SqlDelightExtension {
   internal var configuringDatabase: SqlDelightDatabase? = null
   internal lateinit var project: Project
 
+  var linkSqlite = true
+
   // TODO: Remove these after 1.1.0
   var packageName: String? = null
     set(value) = newDsl()

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
@@ -68,7 +68,9 @@ open class SqlDelightPlugin : Plugin<Project> {
         )
       }
 
-      project.linkSqlite()
+      if (extension.linkSqlite) {
+        project.linkSqlite()
+      }
     }
 
     // Using projectsEvaluated instead of afterEvaluate because the kotlin plugin configures

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
@@ -22,14 +22,13 @@ internal class TemporaryFixture : AutoCloseable {
     File(fixtureRoot, "build.gradle").apply { createNewFile() }.writeText(text)
   }
 
-  internal fun configure() {
+  internal fun configure(runTask: String = "clean") {
     val result = GradleRunner.create()
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
-        .withArguments("clean", "--stacktrace")
+        .withArguments(runTask, "--stacktrace")
         .forwardOutput()
         .build()
-
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
 


### PR DESCRIPTION
This allows native users of SQLDelight to link their own sqlite, which is useful if you want to use something other than system sqlite (i.e. compile in json1 or FTS).