### PR TITLE
only build the notify query list when the transaction is done

### DIFF
--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
@@ -40,7 +40,7 @@ class TestDb(
   }
 
   fun notify(key: String) {
-    queries[key]?.let { notifyQueries(it) }
+    queries[key]?.let { notifyQueries(key.hashCode(), { it }) }
   }
 
   fun close() {

--- a/extensions/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/TestDb.kt
+++ b/extensions/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/TestDb.kt
@@ -39,7 +39,7 @@ class TestDb(
   }
 
   fun notify(key: String) {
-    queries[key]?.let { notifyQueries(it) }
+    queries[key]?.let { notifyQueries(key.hashCode(), {it}) }
   }
 
   fun close() {

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -240,8 +240,8 @@ private class PlayerQueriesImpl(private val database: TestDatabaseImpl, private 
             bindString(3, team)
             bindString(4, database.playerAdapter.shootsAdapter.encode(shoots))
         }
-        notifyQueries(database.playerQueries.allPlayers + database.playerQueries.playersForTeam +
-                database.playerQueries.playersForNumbers)
+        notifyQueries(105,  queryList = {database.playerQueries.allPlayers + database.playerQueries.playersForTeam +
+                database.playerQueries.playersForNumbers})
     }
 
     override fun updateTeamForNumbers(team: String?, number: Collection<Long>) {
@@ -256,8 +256,9 @@ private class PlayerQueriesImpl(private val database: TestDatabaseImpl, private 
                     bindLong(index + 2, number)
                     }
         }
-        notifyQueries(database.playerQueries.allPlayers + database.playerQueries.playersForTeam +
-                database.playerQueries.playersForNumbers)
+        //TODO: this is a db write operation,  why the identifier here is null???
+        notifyQueries(0 , {database.playerQueries.allPlayers + database.playerQueries.playersForTeam +
+                database.playerQueries.playersForNumbers})
     }
 
     override fun foreignKeysOn() {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/MutatorQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/MutatorQueryGenerator.kt
@@ -60,8 +60,9 @@ class MutatorQueryGenerator(
     // The list of effected queries:
     // (queryWrapper.dataQueries.selectForId + queryWrapper.otherQueries.selectForId)
     // TODO: Only notify queries that were dirtied (check using dirtied method).
-    addStatement("notifyQueries(%L)",
-        resultSetsUpdated.map { it.queryProperty }.joinToCode(separator = " + "))
+    addStatement("notifyQueries(%L, {%L})",
+            query.id,
+            resultSetsUpdated.map { it.queryProperty }.joinToCode(separator = " + "))
 
     return this
   }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -107,7 +107,7 @@ class QueriesTypeTest {
       |            bindString(2, if (value == null) null else
       |                    database.dataAdapter.valueAdapter.encode(value))
       |        }
-      |        notifyQueries(database.dataQueries.selectForId)
+      |        notifyQueries(${insert.id}, {database.dataQueries.selectForId})
       |    }
       |
       |    private inner class SelectForId<out T : Any>(private val id: Long, mapper: (SqlCursor) -> T) :

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -114,7 +114,7 @@ class MutatorQueryTypeTest {
       |        bindLong(1, if (id == null) null else id.toLong())
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
-      |    notifyQueries(database.dataQueries.selectForId)
+      |    notifyQueries(${mutator.id}, {database.dataQueries.selectForId})
       |}
       |""".trimMargin())
   }
@@ -150,7 +150,7 @@ class MutatorQueryTypeTest {
       |        bindLong(1, if (id == null) null else id.toLong())
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
-      |    notifyQueries(database.otherDataQueries.selectForId)
+      |    notifyQueries(${mutator.id}, {database.otherDataQueries.selectForId})
       |}
       |""".trimMargin())
   }
@@ -265,7 +265,7 @@ class MutatorQueryTypeTest {
       |    |  ON data.id = data2.id
       |    |)
       |    ""${'"'}.trimMargin(), 0)
-      |    notifyQueries(database.dataQueries.selectForId)
+      |    notifyQueries(${mutator.id}, {database.dataQueries.selectForId})
       |}
       |""".trimMargin())
   }
@@ -394,7 +394,7 @@ class MutatorQueryTypeTest {
       |        bindLong(3, if (deprecated) 1L else 0L)
       |        bindString(4, link)
       |    }
-      |    notifyQueries(database.dataQueries.queryTerm)
+      |    notifyQueries(${mutator.id}, {database.dataQueries.queryTerm})
       |}
       |""".trimMargin())
   }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/triggers/TriggerNotificationTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/triggers/TriggerNotificationTest.kt
@@ -50,7 +50,7 @@ class MutatorQueryFunctionTest {
       |        bindLong(1, id)
       |        bindString(2, value)
       |    }
-      |    notifyQueries(database.testQueries.selectData2)
+      |    notifyQueries(${mutator.id}, {database.testQueries.selectData2})
       |}
       |""".trimMargin())
   }
@@ -186,7 +186,7 @@ class MutatorQueryFunctionTest {
       |        bindString(1, value)
       |        bindLong(2, id)
       |    }
-      |    notifyQueries(database.testQueries.selectData2)
+      |    notifyQueries(${mutator.id}, {database.testQueries.selectData2})
       |}
       |""".trimMargin())
   }
@@ -233,7 +233,7 @@ class MutatorQueryFunctionTest {
       |        bindString(1, value)
       |        bindLong(2, id)
       |    }
-      |    notifyQueries(database.testQueries.selectData2)
+      |    notifyQueries(${mutator.id}, {database.testQueries.selectData2})
       |}
       |""".trimMargin())
   }

--- a/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
+++ b/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
@@ -179,7 +179,10 @@ abstract class TransacterImpl(private val driver: SqlDriver) : Transacter {
           }
           transaction.postRollbackHooks.clear()
         } else {
-          transaction.queriesFuncs.forEach { it.value.invoke().invoke().forEach { it.notifyDataChanged() } }
+          sharedSet<Query<*>>().apply { transaction.queriesFuncs
+                  .forEach { this.addAll(it.value.invoke().invoke())} }
+                  .forEach { it.notifyDataChanged() }
+
           transaction.queriesFuncs.clear()
           transaction.postCommitHooks.forEach { it.run() }
           transaction.postCommitHooks.clear()

--- a/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
+++ b/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
@@ -179,9 +179,10 @@ abstract class TransacterImpl(private val driver: SqlDriver) : Transacter {
           }
           transaction.postRollbackHooks.clear()
         } else {
-          sharedSet<Query<*>>().apply { transaction.queriesFuncs
-                  .forEach { this.addAll(it.value.invoke().invoke())} }
-                  .forEach { it.notifyDataChanged() }
+          transaction.queriesFuncs
+                  .map { (_, queryListSupplier) -> queryListSupplier.invoke().invoke()}
+                  .distinct()
+                  .forEach { it.forEach { it.notifyDataChanged() } }
 
           transaction.queriesFuncs.clear()
           transaction.postCommitHooks.forEach { it.run() }

--- a/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/sqldelight-runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -13,3 +13,5 @@ internal expect class QueryLock()
 internal expect inline fun <T> QueryLock.withLock(block: () -> T): T
 
 internal expect fun <T> sharedSet(): MutableSet<T>
+
+internal expect fun <T, R> sharedMap(): MutableMap<T, R>

--- a/sqldelight-runtime/src/jsMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/sqldelight-runtime/src/jsMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -18,3 +18,5 @@ internal actual fun <T> threadLocalRef(value: T): () -> T {
 }
 
 internal actual fun <T> sharedSet(): MutableSet<T> = mutableSetOf()
+
+internal actual fun <T, R> sharedMap(): MutableMap<T, R> = mutableMapOf()

--- a/sqldelight-runtime/src/jvmMain/kotlin/com/squareup/sqldelight/internal/FunctionsJvm.kt
+++ b/sqldelight-runtime/src/jvmMain/kotlin/com/squareup/sqldelight/internal/FunctionsJvm.kt
@@ -22,3 +22,5 @@ internal actual fun <T> threadLocalRef(value: T): () -> T {
 }
 
 internal actual fun <T> sharedSet(): MutableSet<T> = mutableSetOf()
+
+internal actual fun <T, R> sharedMap(): MutableMap<T, R> = mutableMapOf()

--- a/sqldelight-runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/sqldelight-runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -7,6 +7,7 @@ import co.touchlab.stately.collections.frozenCopyOnWriteList
 import co.touchlab.stately.concurrency.value
 import co.touchlab.stately.concurrency.withLock
 import com.squareup.sqldelight.Query
+import co.touchlab.stately.collections.SharedHashMap
 
 actual fun copyOnWriteList(): MutableList<Query<*>> {
   return frozenCopyOnWriteList()
@@ -25,3 +26,5 @@ internal actual fun <T> threadLocalRef(value: T): () -> T {
 }
 
 internal actual fun <T> sharedSet(): MutableSet<T> = SharedSet<T>()
+
+internal actual fun <T, R> sharedMap(): MutableMap<T, R> = SharedHashMap<T, R>()


### PR DESCRIPTION
Background:
We have lots of queries listening to database table, and we mostly do update inside transaction. Currently the `notifyQueries` is called after each db update. Even within a transaction, the query list is built every time when `notifyQueries` is called. The cost of building the list after every single db update is high,  when most of the query list is not empty, and when the number of update is high. 

Change:
Change the interface on Transacter `notifyQueries(notifyQueries(queryList: List<Query<*>>) )`
to `notifyQueries(identifier: Int, queryList: () -> List<Query<*>>)`

If the notify happens outside a transaction, notify it right away. Otherwise cache the function with the identifier. When transaction is committed, invoke the function to build query list and do the notification. 

Test:
Before the change. I have a same insert query, one with 100 subscribers. One has 0 subscribers. Call insert 1000 time inside a transaction, the one with 100 subscribers perf 3x slower than the one does not. After the change, they almost perf the same. 

