### PR TITLE
Force JdbcSqliteDriver users to supply a DB URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ dependencies {
 }
 ```
 ```kotlin
-val driver: SqlDriver = JdbcSqliteDriver()
+val driver: SqlDriver = JdbcSqliteDriver(IN_MEMORY)
 Database.Schema.create(driver)
 ```
 

--- a/drivers/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/JdbcSqliteDriver.kt
+++ b/drivers/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/JdbcSqliteDriver.kt
@@ -1,20 +1,32 @@
 package com.squareup.sqldelight.sqlite.driver
 
 import com.squareup.sqldelight.Transacter
+import com.squareup.sqldelight.db.SqlCursor
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlPreparedStatement
-import com.squareup.sqldelight.db.SqlCursor
 import java.sql.DriverManager
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Types
 import java.util.Properties
+import kotlin.DeprecationLevel.ERROR
 
 class JdbcSqliteDriver constructor(
-  name: String = "jdbc:sqlite:",
+  /**
+   * Database connection URL in the form of `jdbc:sqlite:path` where `path` is either blank
+   * (creating an in-memory database) or a path to a file.
+   */
+  url: String,
   properties: Properties = Properties()
 ) : SqlDriver {
-  private val connection = DriverManager.getConnection(name, properties)
+  companion object {
+    const val IN_MEMORY = "jdbc:sqlite:"
+  }
+
+  @Deprecated("Specify connection URL explicitly", ReplaceWith("JdbcSqliteDriver(IN_MEMORY, properties)"), ERROR)
+  constructor(properties: Properties = Properties()) : this(IN_MEMORY, properties)
+
+  private val connection = DriverManager.getConnection(url, properties)
   private val transactions = ThreadLocal<Transacter.Transaction>()
 
   override fun close() = connection.close()

--- a/drivers/sqlite-driver/src/test/kotlin/com/squareup/sqldelight/driver/sqlite/SqliteDriverTest.kt
+++ b/drivers/sqlite-driver/src/test/kotlin/com/squareup/sqldelight/driver/sqlite/SqliteDriverTest.kt
@@ -4,10 +4,11 @@ import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlDriver.Schema
 import com.squareup.sqldelight.driver.test.DriverTest
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 
 class SqliteDriverTest : DriverTest() {
   override fun setupDatabase(schema: Schema): SqlDriver {
-    val database = JdbcSqliteDriver()
+    val database = JdbcSqliteDriver(IN_MEMORY)
     schema.create(database)
     return database
   }

--- a/drivers/sqlite-driver/src/test/kotlin/com/squareup/sqldelight/driver/sqlite/SqliteQueryTest.kt
+++ b/drivers/sqlite-driver/src/test/kotlin/com/squareup/sqldelight/driver/sqlite/SqliteQueryTest.kt
@@ -4,10 +4,11 @@ import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlDriver.Schema
 import com.squareup.sqldelight.driver.test.QueryTest
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 
 class SqliteQueryTest: QueryTest() {
   override fun setupDatabase(schema: Schema): SqlDriver {
-    val database = JdbcSqliteDriver()
+    val database = JdbcSqliteDriver(IN_MEMORY)
     schema.create(database)
     return database
   }

--- a/drivers/sqlite-driver/src/test/kotlin/com/squareup/sqldelight/driver/sqlite/SqliteTransacterTest.kt
+++ b/drivers/sqlite-driver/src/test/kotlin/com/squareup/sqldelight/driver/sqlite/SqliteTransacterTest.kt
@@ -4,10 +4,11 @@ import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlDriver.Schema
 import com.squareup.sqldelight.driver.test.TransacterTest
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 
 class SqliteTransacterTest : TransacterTest() {
   override fun setupDatabase(schema: Schema): SqlDriver {
-    val database = JdbcSqliteDriver()
+    val database = JdbcSqliteDriver(IN_MEMORY)
     schema.create(database)
     return database
   }

--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
@@ -18,5 +18,6 @@ package com.squareup.sqldelight.runtime.coroutines
 
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 
-actual fun testDriver(): SqlDriver = JdbcSqliteDriver()
+actual fun testDriver(): SqlDriver = JdbcSqliteDriver(IN_MEMORY)

--- a/extensions/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/TestDb.kt
+++ b/extensions/rxjava2-extensions/src/test/kotlin/com/squareup/sqldelight/runtime/rx/TestDb.kt
@@ -8,9 +8,10 @@ import com.squareup.sqldelight.internal.copyOnWriteList
 import com.squareup.sqldelight.runtime.rx.TestDb.Companion.TABLE_EMPLOYEE
 import com.squareup.sqldelight.runtime.rx.TestDb.Companion.TABLE_MANAGER
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 
 class TestDb(
-  val db: SqlDriver = JdbcSqliteDriver()
+  val db: SqlDriver = JdbcSqliteDriver(IN_MEMORY)
 ) : TransacterImpl(db) {
   val queries = mutableMapOf<String, MutableList<Query<*>>>()
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/squareup/sqldelight/core/integration/IntegrationTest.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/squareup/sqldelight/core/integration/IntegrationTest.kt
@@ -1,6 +1,5 @@
 package com.squareup.sqldelight.core.integration
 
-import com.example.Group
 import com.example.Player
 import com.example.Team
 import com.example.TestDatabase
@@ -12,6 +11,7 @@ import com.squareup.sqldelight.core.integration.Shoots.RIGHT
 import com.squareup.sqldelight.core.integration.Shoots.Type.ONE
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 import com.squareup.sqldelight.test.util.FixtureCompiler
 import com.squareup.sqldelight.test.util.fixtureRoot
 import org.junit.After
@@ -130,7 +130,7 @@ class IntegrationTest {
   }
 
   @Before fun setupDb() {
-    driver = JdbcSqliteDriver()
+    driver = JdbcSqliteDriver(IN_MEMORY)
     queryWrapper = TestDatabase(driver, playerAdapter, teamAdapter)
     TestDatabase.Schema.create(driver)
   }

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/androidMain/kotlin/com/squareup/sqldelight/integration/android.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/androidMain/kotlin/com/squareup/sqldelight/integration/android.kt
@@ -2,12 +2,13 @@ package com.squareup.sqldelight.integration
 
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 
 actual fun createSqlDatabase(): SqlDriver {
-  return JdbcSqliteDriver().apply {
+  return JdbcSqliteDriver(IN_MEMORY).apply {
     QueryWrapper.Schema.create(this)
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
@@ -1,6 +1,7 @@
 package com.squareup.sqldelight.integration
 
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.ColumnAdapter
 import java.util.Arrays
@@ -26,7 +27,7 @@ class IntegrationTests {
   }
 
   @Before fun before() {
-    val database = JdbcSqliteDriver()
+    val database = JdbcSqliteDriver(IN_MEMORY)
     QueryWrapper.Schema.create(database)
 
     queryWrapper = QueryWrapper(database, NullableTypes.Adapter(listAdapter))

--- a/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/androidTest/java/com/squareup/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/androidTest/java/com/squareup/sqldelight/integration/IntegrationTests.kt
@@ -2,6 +2,7 @@ package com.squareup.sqldelight.integration
 
 import com.example.android.Database
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.Query
 import org.junit.Before
@@ -13,7 +14,7 @@ class IntegrationTests {
   private lateinit var database: Database
 
   @Before fun before() {
-    val driver = JdbcSqliteDriver()
+    val driver = JdbcSqliteDriver(IN_MEMORY)
     Database.Schema.create(driver)
 
     database = Database(driver)

--- a/sqldelight-gradle-plugin/src/test/multi-module/ProjectA/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/multi-module/ProjectA/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
@@ -2,6 +2,7 @@ package com.squareup.sqldelight.integration
 
 import com.example.Database
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.Query
 import org.junit.Before
@@ -13,7 +14,7 @@ class IntegrationTests {
   private lateinit var database: Database
 
   @Before fun before() {
-    val driver = JdbcSqliteDriver()
+    val driver = JdbcSqliteDriver(IN_MEMORY)
     Database.Schema.create(driver)
 
     database = Database(driver)


### PR DESCRIPTION
Previously the default behavior created an in-memory database by default which is potentially surprising behavior.