### PR TITLE
Add json functions to .sq dsl

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -52,7 +52,7 @@ internal data class IntermediateType(
    */
   val bindArg: SqliteBindExpr? = null,
   /**
-   * Wether or not this argument is extracted from a different type
+   * Whether or not this argument is extracted from a different type
    */
   val extracted: Boolean = false
 ) {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
@@ -177,6 +177,19 @@ private fun SqliteFunctionExpr.functionType() = result@when (functionName.text.t
   "nullif" -> exprList[0].type().asNullable()
   "max" -> encapsulatingType(exprList, INTEGER, REAL, TEXT, BLOB).asNullable()
   "min" -> encapsulatingType(exprList, BLOB, TEXT, INTEGER, REAL).asNullable()
+
+  // json1
+
+  "json", "json_remove", "json_extract", "json_insert", "json_replace", "json_set" -> {
+    IntermediateType(TEXT).nullableIf(exprList[0].type().javaType.isNullable)
+  }
+  "json_array", "json_object", "json_group_array", "json_group_object" -> IntermediateType(TEXT)
+  "json_array_length" -> IntermediateType(INTEGER).nullableIf(exprList[0].type().javaType.isNullable)
+  "json_patch" -> IntermediateType(TEXT).nullableIf(exprList.any { it.type().javaType.isNullable })
+  "json_type" -> IntermediateType(TEXT).asNullable()
+  "json_valid" -> IntermediateType(INTEGER, BOOLEAN)
+  "json_quote" -> exprList[0].type().asNonNullable()
+
   else -> throw AssertionError()
 }
 


### PR DESCRIPTION
This adds support for json1 extension functions to the sqldelight-compiler