### PR TITLE
Support for configure-on-demand

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -33,16 +33,16 @@ class SqlDelightDatabase(
   }
 
   fun dependency(dependencyProject: Project) {
-    dependencyProject.afterEvaluate {
-      val dependency = dependencyProject.extensions.findByType(SqlDelightExtension::class.java)
-          ?: throw IllegalStateException("Cannot depend on a module with no sqldelight plugin.")
-      val database = dependency.databases.singleOrNull { it.name == name }
-          ?: throw IllegalStateException("No database named $name in $dependencyProject")
-      if (database.packageName == packageName) {
-        throw IllegalStateException("Detected a schema that already has the package name $packageName in project $dependencyProject")
-      }
-      dependencies.add(database)
+    project.evaluationDependsOn(dependencyProject.path)
+
+    val dependency = dependencyProject.extensions.findByType(SqlDelightExtension::class.java)
+        ?: throw IllegalStateException("Cannot depend on a module with no sqldelight plugin.")
+    val database = dependency.databases.singleOrNull { it.name == name }
+        ?: throw IllegalStateException("No database named $name in $dependencyProject")
+    if (database.packageName == packageName) {
+      throw IllegalStateException("Detected a schema that already has the package name $packageName in project $dependencyProject")
     }
+    dependencies.add(database)
   }
 
   internal fun getProperties(): SqlDelightDatabaseProperties {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
@@ -71,12 +71,6 @@ open class SqlDelightPlugin : Plugin<Project> {
       if (extension.linkSqlite) {
         project.linkSqlite()
       }
-    }
-
-    // Using projectsEvaluated instead of afterEvaluate because the kotlin plugin configures
-    // source sets during afterEvaluate which we rely on.
-    project.gradle.projectsEvaluated {
-      val isMultiplatform = project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
 
       extension.run {
         if (databases.isEmpty() && android && !isMultiplatform) {

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/build.gradle
@@ -1,0 +1,56 @@
+plugins {
+  id 'org.jetbrains.kotlin.multiplatform'
+  id 'com.squareup.sqldelight'
+}
+
+apply from: '../../../../gradle/dependencies.gradle'
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+  }
+  mavenCentral()
+}
+
+sqldelight {
+  Database {
+    packageName = "com.sample"
+  }
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation deps.kotlin.stdlib.common
+      }
+    }
+    jvmMain {
+      dependencies {
+        implementation deps.kotlin.stdlib.jdk
+      }
+    }
+    jsMain {
+      dependencies {
+        implementation deps.kotlin.stdlib.js
+      }
+    }
+  }
+  targetFromPreset(presets.jvm, 'jvm')
+  targetFromPreset(presets.js, 'js')
+  targetFromPreset(presets.iosArm32, 'iosArm32') {
+    binaries {
+      framework()
+    }
+  }
+  targetFromPreset(presets.iosArm64, 'iosArm64') {
+    binaries {
+      framework()
+    }
+  }
+  targetFromPreset(presets.iosX64, 'iosX64') {
+    binaries {
+      framework()
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/gradle.properties
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configureondemand=true

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/settings.gradle
@@ -1,0 +1,1 @@
+enableFeaturePreview('GRADLE_METADATA')

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/src/commonMain/sqldelight/com/sample/Test.sq
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/src/commonMain/sqldelight/com/sample/Test.sq
@@ -1,0 +1,4 @@
+CREATE TABLE test (
+  value2 TEXT NOT NULL,
+  value TEXT NOT NULL
+);

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
@@ -89,6 +89,7 @@ class MultiModuleTests {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
         .withArguments("clean", "--stacktrace")
+        .forwardOutput()
         .build()
 
     // verify

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
@@ -107,6 +107,24 @@ class PluginTest {
   }
 
   @Test
+  fun someTest() {
+    val fixtureRoot = File("src/test/kotlin-mpp-configure-on-demand")
+    val runner = GradleRunner.create()
+        .withProjectDir(fixtureRoot)
+        .withPluginClasspath()
+        .forwardOutput()
+
+    val buildDir = File(fixtureRoot, "build/sqldelight")
+
+    buildDir.delete()
+    val result = runner
+        .withArguments("clean", "compileKotlinJvm", "--stacktrace")
+        .build()
+    assertThat(result.output).contains("generateJvmMainDatabaseInterface")
+    assertThat(buildDir.exists()).isTrue()
+  }
+
+  @Test
   @Category(IosTest::class)
   fun `The generate task is a dependency of multiplatform ios target`() {
     val fixtureRoot = File("src/test/kotlin-mpp")


### PR DESCRIPTION
this gets rid of the reference to `projectsEvaluated`, and instead makes a lot of assumptions about how the kotlin multiplatform plugin organizes the source sets based on android variants. It's not great, but the kotlin and android plugins dont really provide the API's I would need to do this proper, so here we are.