### PR TITLE
Add @CacheableTask annotation to tasks

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
@@ -23,7 +23,9 @@ open class GenerateSchemaTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input fun pluginVersion() = VERSION
 
-  @get:OutputDirectory var outputDirectory: File? = null
+  @get:OutputDirectory
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  var outputDirectory: File? = null
 
   @Internal lateinit var sourceFolders: Iterable<File>
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
@@ -14,9 +14,11 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.CacheableTask
 import java.io.File
 import java.sql.DriverManager
 
+@CacheableTask
 open class GenerateSchemaTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input fun pluginVersion() = VERSION

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -32,8 +32,10 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.CacheableTask
 import java.io.File
 
+@CacheableTask
 open class SqlDelightTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input fun pluginVersion() = VERSION

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -40,7 +40,9 @@ open class SqlDelightTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input fun pluginVersion() = VERSION
 
-  @get:OutputDirectory var outputDirectory: File? = null
+  @get:OutputDirectory
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  var outputDirectory: File? = null
 
   @Internal lateinit var sourceFolders: Iterable<File>
   @Internal lateinit var dependencySourceFolders: Iterable<File>

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
@@ -17,10 +17,8 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.CacheableTask
 import java.io.File
 
-@CacheableTask
 open class VerifyMigrationTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input fun pluginVersion() = VERSION

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
@@ -17,8 +17,10 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.CacheableTask
 import java.io.File
 
+@CacheableTask
 open class VerifyMigrationTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input fun pluginVersion() = VERSION


### PR DESCRIPTION
**Background**
By default gradle tasks do not cache. 

**Change**
* Add `@CacheableTask` annotation to custom tasks

**Test Plan**
* Tested `generateDebug${dbName}Interface` task properly fetched from cache

```
> Task :storage:generateDebugStorageDatabaseInterface FROM-CACHE
Custom actions are attached to task ':storage:generateDebugStorageDatabaseInterface'.
Appending implementation to build cache key: com.squareup.sqldelight.gradle.SqlDelightTask_Decorated@811fa9669948b4e5154393fe4a1f21aa
Appending additional implementation to build cache key: _BuildScript_$_run_closure2$_closure6$_closure7_5e678643d94af11f7401d007fc7e139d@dd98cb2818a7a973d14370b4ca5e675f
Appending additional implementation to build cache key: com.squareup.sqldelight.gradle.SqlDelightTask_Decorated@811fa9669948b4e5154393fe4a1f21aa
Appending additional implementation to build cache key: _BuildScript_$_run_closure2$_closure6$_closure8_1f98c42ebbcbff2ee73aa2ee42bc8837@dd98cb2818a7a973d14370b4ca5e675f
Appending input file fingerprints for 'source' to build cache key: f57eccb33f50987ceb26b5caa6f15e86
Appending output property name to build cache key: outputDirectory
Build cache key for task ':storage:generateDebugStorageDatabaseInterface' is f11976a9da37128d5d51cd46098fb235
```