### PR TITLE
refactor flow assert

### DIFF
--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
@@ -57,7 +57,7 @@ suspend fun <T> Flow<T>.test(timeoutMs: Long = 1000L, validate: suspend FlowAsse
       false
     }
     if (ensureConsumed) {
-      flowAssert.noMoreEvents()
+      flowAssert.expectNoMoreEvents()
     }
   }
 }
@@ -101,7 +101,7 @@ class FlowAssert<T> internal constructor(
     }
   }
 
-  suspend fun noMoreEvents() {
+  suspend fun expectNoMoreEvents() {
     val event = withTimeout {
       events.receiveOrNull()
     }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
@@ -129,7 +129,7 @@ class FlowAssert<T> internal constructor(
     }
   }
 
-  suspend fun error(): Throwable {
+  suspend fun expectError(): Throwable {
     val event = withTimeout {
       events.receive()
     }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
@@ -120,7 +120,7 @@ class FlowAssert<T> internal constructor(
     return event.item
   }
 
-  suspend fun complete() {
+  suspend fun expectComplete() {
     val event = withTimeout {
       events.receive()
     }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
@@ -94,7 +94,7 @@ class FlowAssert<T> internal constructor(
     throw ignoreRemainingEventsException
   }
 
-  fun noEvents() {
+  fun expectNoEvents() {
     val event = events.poll()
     if (event != null) {
       throw AssertionError("Expected no events but found $event")

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowAssert.kt
@@ -110,7 +110,7 @@ class FlowAssert<T> internal constructor(
     }
   }
 
-  suspend fun item(): T {
+  suspend fun expectItem(): T {
     val event = withTimeout {
       events.receive()
     }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
@@ -28,7 +28,7 @@ class MappingTest {
         .asFlow()
         .mapToOne()
         .test {
-          assertEquals(Employee("alice", "Alice Allison"), item())
+          assertEquals(Employee("alice", "Alice Allison"), expectItem())
           cancel()
         }
   }
@@ -79,7 +79,7 @@ class MappingTest {
         .asFlow()
         .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
         .test {
-          assertEquals(Employee("alice", "Alice Allison"), item())
+          assertEquals(Employee("alice", "Alice Allison"), expectItem())
           cancel()
         }
   }
@@ -132,7 +132,7 @@ class MappingTest {
         .asFlow()
         .mapToOneOrDefault(defaultEmployee)
         .test {
-          assertSame(defaultEmployee, item())
+          assertSame(defaultEmployee, expectItem())
           cancel()
         }
   }
@@ -146,7 +146,7 @@ class MappingTest {
               Employee("alice", "Alice Allison"), //
               Employee("bob", "Bob Bobberson"), //
               Employee("eve", "Eve Evenson")
-          ), item())
+          ), expectItem())
           cancel()
         }
   }
@@ -187,7 +187,7 @@ class MappingTest {
         .asFlow()
         .mapToList()
         .test {
-          assertEquals(emptyList(), item())
+          assertEquals(emptyList(), expectItem())
           cancel()
         }
   }
@@ -197,7 +197,7 @@ class MappingTest {
         .asFlow()
         .mapToOneOrNull()
         .test {
-          assertEquals(Employee("alice", "Alice Allison"), item())
+          assertEquals(Employee("alice", "Alice Allison"), expectItem())
           cancel()
         }
   }
@@ -247,7 +247,7 @@ class MappingTest {
         .asFlow()
         .mapToOneOrNull()
         .test {
-          assertNull(item())
+          assertNull(expectItem())
           cancel()
         }
   }
@@ -257,7 +257,7 @@ class MappingTest {
         .asFlow()
         .mapToOneNotNull()
         .test {
-          assertEquals(Employee("alice", "Alice Allison"), item())
+          assertEquals(Employee("alice", "Alice Allison"), expectItem())
           cancel()
         }
   }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
@@ -41,7 +41,7 @@ class MappingTest {
         .mapToOne()
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -58,7 +58,7 @@ class MappingTest {
         .mapToOne()
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -69,7 +69,7 @@ class MappingTest {
         .asFlow()
         .mapToOne()
         .test {
-          val message = error().message!!
+          val message = expectError().message!!
           assertTrue("ResultSet returned more than 1 row" in message, message)
         }
   }
@@ -92,7 +92,7 @@ class MappingTest {
         .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -109,7 +109,7 @@ class MappingTest {
         .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -120,7 +120,7 @@ class MappingTest {
         .asFlow()
         .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
         .test {
-          val message = error().message!!
+          val message = expectError().message!!
           assertTrue("ResultSet returned more than 1 row" in message, message)
         }
   }
@@ -159,7 +159,7 @@ class MappingTest {
         .mapToList()
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -176,7 +176,7 @@ class MappingTest {
         .mapToList()
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -209,7 +209,7 @@ class MappingTest {
         .mapToOneOrNull()
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -226,7 +226,7 @@ class MappingTest {
         .mapToOneOrNull()
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -237,7 +237,7 @@ class MappingTest {
         .asFlow()
         .mapToOneOrNull()
         .test {
-          val message = error().message!!
+          val message = expectError().message!!
           assertTrue("ResultSet returned more than 1 row" in message, message)
         }
   }
@@ -270,7 +270,7 @@ class MappingTest {
         .mapToOneNotNull()
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }
@@ -287,7 +287,7 @@ class MappingTest {
         .mapToOneNotNull()
         .test {
           // We can't assertSame because coroutines break exception referential transparency.
-          val actual = error()
+          val actual = expectError()
           assertEquals(IllegalStateException::class, actual::class)
           assertEquals(expected.message, actual.message)
         }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
@@ -299,7 +299,7 @@ class MappingTest {
         .take(1) // Ensure we have an event (complete) that the script can validate.
         .mapToOneNotNull()
         .test {
-          complete()
+          expectComplete()
         }
   }
 }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
@@ -27,7 +27,7 @@ class QueryAsFlowTest {
     db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
         .asFlow()
         .test {
-          item().assert {
+          expectItem().assert {
             hasRow("alice", "Alice Allison")
             hasRow("bob", "Bob Bobberson")
             hasRow("eve", "Eve Evenson")
@@ -41,14 +41,14 @@ class QueryAsFlowTest {
     db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
         .asFlow()
         .test {
-          item().assert {
+          expectItem().assert {
             hasRow("alice", "Alice Allison")
             hasRow("bob", "Bob Bobberson")
             hasRow("eve", "Eve Evenson")
           }
 
           db.employee(Employee("john", "John Johnson"))
-          item().assert {
+          expectItem().assert {
             hasRow("alice", "Alice Allison")
             hasRow("bob", "Bob Bobberson")
             hasRow("eve", "Eve Evenson")
@@ -63,7 +63,7 @@ class QueryAsFlowTest {
     db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
         .asFlow()
         .test {
-          item().assert {
+          expectItem().assert {
             hasRow("alice", "Alice Allison")
             hasRow("bob", "Bob Bobberson")
             hasRow("eve", "Eve Evenson")
@@ -83,7 +83,7 @@ class QueryAsFlowTest {
     db.employee(Employee("john", "John Johnson"))
 
     flow.test {
-      item().assert {
+      expectItem().assert {
         hasRow("alice", "Alice Allison")
         hasRow("bob", "Bob Bobberson")
         hasRow("eve", "Eve Evenson")
@@ -102,7 +102,7 @@ class QueryAsFlowTest {
         .test {
           val employee = Employee("john", "John Johnson")
           db.employee(employee)
-          assertEquals(employee to employee, item())
+          assertEquals(employee to employee, expectItem())
 
           cancel()
         }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
@@ -72,7 +72,7 @@ class QueryAsFlowTest {
           cancel()
 
           db.employee(Employee("john", "John Johnson"))
-          noMoreEvents()
+          expectNoMoreEvents()
         }
   }
 


### PR DESCRIPTION
rename the following `FlowAssert` functions:

`noEvents` -> `expectNoEvents`

`noMoreEvents` -> `expectNoMoreEvents`

`item` -> `expectItem`

`complete` -> `expectComplete`

`error` -> `expectError`