### PR TITLE
Remove whitespace and comments from rawSql

### DIFF
--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -67,12 +67,7 @@ class QueriesTypeTest {
       |            get() = 1
       |
       |        override fun create(driver: SqlDriver) {
-      |            driver.execute(null, ""${'"'}
-      |                    |CREATE TABLE data (
-      |                    |  id INTEGER PRIMARY KEY,
-      |                    |  value TEXT
-      |                    |)
-      |                    ""${'"'}.trimMargin(), 0)
+      |            driver.execute(null, "CREATE TABLE data (id INTEGER PRIMARY KEY, value TEXT)", 0)
       |        }
       |
       |        override fun migrate(
@@ -99,10 +94,7 @@ class QueriesTypeTest {
       |    override fun selectForId(id: Long): Query<Data> = selectForId(id, Data::Impl)
       |
       |    override fun insertData(id: Long?, value: List?) {
-      |        driver.execute(${insert.id}, ""${'"'}
-      |        |INSERT INTO data
-      |        |VALUES (?1, ?2)
-      |        ""${'"'}.trimMargin(), 2) {
+      |        driver.execute(${insert.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |            bindLong(1, id)
       |            bindString(2, if (value == null) null else
       |                    database.dataAdapter.valueAdapter.encode(value))
@@ -112,11 +104,8 @@ class QueriesTypeTest {
       |
       |    private inner class SelectForId<out T : Any>(private val id: Long, mapper: (SqlCursor) -> T) :
       |            Query<T>(selectForId, mapper) {
-      |        override fun execute(): SqlCursor = driver.executeQuery(${select.id}, ""${'"'}
-      |        |SELECT *
-      |        |FROM data
-      |        |WHERE id = ?1
-      |        ""${'"'}.trimMargin(), 1) {
+      |        override fun execute(): SqlCursor = driver.executeQuery(${select.id},
+      |                ""${'"'}SELECT * FROM data WHERE id = ?1""${'"'}, 1) {
       |            bindLong(1, id)
       |        }
       |

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueryWrapperTest.kt
@@ -49,16 +49,9 @@ class QueryWrapperTest {
       |            get() = 1
       |
       |        override fun create(driver: SqlDriver) {
-      |            driver.execute(null, ""${'"'}
-      |                    |CREATE TABLE test_table(
-      |                    |  _id INTEGER NOT NULL PRIMARY KEY,
-      |                    |  value TEXT
-      |                    |)
-      |                    ""${'"'}.trimMargin(), 0)
-      |            driver.execute(null, ""${'"'}
-      |                    |INSERT INTO test_table
-      |                    |VALUES (1, 'test')
-      |                    ""${'"'}.trimMargin(), 0)
+      |            driver.execute(null,
+      |                    "CREATE TABLE test_table(_id INTEGER NOT NULL PRIMARY KEY, value TEXT)", 0)
+      |            driver.execute(null, "INSERT INTO test_table VALUES (1, 'test')", 0)
       |        }
       |
       |        override fun migrate(
@@ -127,18 +120,10 @@ class QueryWrapperTest {
         |            get() = 1
         |
         |        override fun create(driver: SqlDriver) {
-        |            driver.execute(null, ""${'"'}
-        |                    |CREATE TABLE test_table(
-        |                    |  _id INTEGER NOT NULL PRIMARY KEY,
-        |                    |  value TEXT
-        |                    |)
-        |                    ""${'"'}.trimMargin(), 0)
-        |            driver.execute(null, ""${'"'}
-        |                    |CREATE TABLE test_table2(
-        |                    |  _id INTEGER NOT NULL PRIMARY KEY,
-        |                    |  value TEXT
-        |                    |)
-        |                    ""${'"'}.trimMargin(), 0)
+        |            driver.execute(null,
+        |                    "CREATE TABLE test_table(_id INTEGER NOT NULL PRIMARY KEY, value TEXT)", 0)
+        |            driver.execute(null,
+        |                    "CREATE TABLE test_table2(_id INTEGER NOT NULL PRIMARY KEY, value TEXT)", 0)
         |        }
         |
         |        override fun migrate(
@@ -194,15 +179,8 @@ class QueryWrapperTest {
         |            get() = 1
         |
         |        override fun create(driver: SqlDriver) {
-        |            driver.execute(null, ""${'"'}
-        |                    |CREATE VIEW A AS
-        |                    |SELECT 1
-        |                    ""${'"'}.trimMargin(), 0)
-        |            driver.execute(null, ""${'"'}
-        |                    |CREATE VIEW B AS
-        |                    |SELECT *
-        |                    |FROM A
-        |                    ""${'"'}.trimMargin(), 0)
+        |            driver.execute(null, "CREATE VIEW A AS SELECT 1", 0)
+        |            driver.execute(null, "CREATE VIEW B AS SELECT * FROM A", 0)
         |        }
         |
         |        override fun migrate(
@@ -263,18 +241,10 @@ class QueryWrapperTest {
         |            get() = 1
         |
         |        override fun create(driver: SqlDriver) {
-        |            driver.execute(null, ""${'"'}
-        |                    |CREATE TABLE test (
-        |                    |  value TEXT
-        |                    |)
-        |                    ""${'"'}.trimMargin(), 0)
-        |            driver.execute(null, ""${'"'}
-        |                    |CREATE TRIGGER A
-        |                    |BEFORE DELETE ON test
-        |                    |BEGIN
-        |                    |INSERT INTO test DEFAULT VALUES;
-        |                    |END
-        |                    ""${'"'}.trimMargin(), 0)
+        |            driver.execute(null, "CREATE TABLE test (value TEXT)", 0)
+        |            driver.execute(null,
+        |                    "CREATE TRIGGER A BEFORE DELETE ON test BEGIN INSERT INTO test DEFAULT VALUES; END",
+        |                    0)
         |            driver.execute(null, "CREATE INDEX B ON test(value)", 0)
         |        }
         |
@@ -336,13 +306,7 @@ class QueryWrapperTest {
         |            get() = 3
         |
         |        override fun create(driver: SqlDriver) {
-        |            driver.execute(null, ""${'"'}
-        |                    |CREATE TABLE test (
-        |                    |  value1 TEXT,
-        |                    |  value2 TEXT,
-        |                    |  value3 REAL
-        |                    |)
-        |                    ""${'"'}.trimMargin(), 0)
+        |            driver.execute(null, "CREATE TABLE test (value1 TEXT, value2 TEXT, value3 REAL)", 0)
         |        }
         |
         |        override fun migrate(
@@ -418,29 +382,17 @@ class QueryWrapperTest {
         |            get() = 1
         |
         |        override fun create(driver: SqlDriver) {
-        |            driver.execute(null, ""${'"'}
-        |                    |CREATE TABLE class_ability_test (
-        |                    |  id TEXT PRIMARY KEY NOT NULL,
-        |                    |  class_id TEXT NOT NULL,
-        |                    |  name TEXT NOT NULL,
-        |                    |  level_id INTEGER NOT NULL DEFAULT 1,
-        |                    |  special TEXT,
-        |                    |  url TEXT NOT NULL
-        |                    |)
-        |                    ""${'"'}.trimMargin(), 0)
-        |            driver.execute(null, buildString(75360) {
-        |                    append(""${'"'}
-        |                    |INSERT INTO class_ability_test(id, class_id, name, level_id, special, url)
-        |                    |VALUES
-        |                    |  ('class_01_ability_0', 'class_01', 'aaaaaaaaaaaaaaa', 1, NULL, 'https://stuff.example.com/this/is/a/bunch/of/path/data/class_01_ability_0.png')
+        |            driver.execute(null,
+        |                    "CREATE TABLE class_ability_test (id TEXT PRIMARY KEY NOT NULL, class_id TEXT NOT NULL, name TEXT NOT NULL, level_id INTEGER NOT NULL DEFAULT 1, special TEXT, url TEXT NOT NULL)",
+        |                    0)
+        |            driver.execute(null, buildString(74360) {
+        |                    append("INSERT INTO class_ability_test(id, class_id, name, level_id, special, url) VALUES ('class_01_ability_0', 'class_01', 'aaaaaaaaaaaaaaa', 1, NULL, 'https://stuff.example.com/this/is/a/bunch/of/path/data/class_01_ability_0.png')
         """.trimMargin())
       contains("""
-        |                    ""${'"'}.trimMargin())
-        |                    append(""${'"'}
+        |                    append("
       """.trimMargin())
       endsWith("""
-        |                    |  ('class_01_ability_499', 'class_01', 'aaaaaaaaaaaaaaa', 1, NULL, 'https://stuff.example.com/this/is/a/bunch/of/path/data/class_01_ability_499.png')
-        |                    ""${'"'}.trimMargin())
+        |('class_01_ability_499', 'class_01', 'aaaaaaaaaaaaaaa', 1, NULL, 'https://stuff.example.com/this/is/a/bunch/of/path/data/class_01_ability_499.png')")
         |                    }, 0)
         |        }
         |

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/JavadocTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/JavadocTest.kt
@@ -134,10 +134,7 @@ class JavadocTest {
       | * Insert new value.
       | */
       |override fun insertValue(value: kotlin.String) {
-      |    driver.execute(${insert.id}, ""${'"'}
-      |    |INSERT INTO test(value)
-      |    |VALUES (?1)
-      |    ""${'"'}.trimMargin(), 1) {
+      |    driver.execute(-608273701, ""${'"'}INSERT INTO test(value) VALUES (?1)""${'"'}, 1) {
       |        bindString(1, value)
       |    }
       |}
@@ -163,11 +160,7 @@ class JavadocTest {
       | * Update value by id.
       | */
       |override fun updateById(value: kotlin.String, _id: kotlin.Long) {
-      |    driver.execute(${update.id}, ""${'"'}
-      |    |UPDATE test
-      |    |SET value = ?1
-      |    |WHERE _id = ?2
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(380275512, ""${'"'}UPDATE test SET value = ?1 WHERE _id = ?2""${'"'}, 2) {
       |        bindString(1, value)
       |        bindLong(2, _id)
       |    }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -27,10 +27,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(id: kotlin.Long?, value: kotlin.collections.List?) {
-      |    driver.execute(${insert.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?1, ?2)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${insert.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |        bindLong(1, id)
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
@@ -55,10 +52,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(id: kotlin.Long?, value: kotlin.collections.List?) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?1, ?2)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |        bindLong(1, id)
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
@@ -104,10 +98,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(data: com.example.Data) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?, ?)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?, ?)""${'"'}, 2) {
       |        bindLong(1, data.id)
       |        bindString(2, if (data.value == null) null else database.dataAdapter.valueAdapter.encode(data.value!!))
       |    }
@@ -133,11 +124,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun updateData(newValue: kotlin.collections.List?, oldValue: kotlin.collections.List?) {
-      |    driver.execute(null, ""${'"'}
-      |    |UPDATE data
-      |    |SET value = ?1
-      |    |WHERE value ${"$"}{ if (oldValue == null) "IS" else "=" } ?2
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(null, ""${'"'}UPDATE data SET value = ?1 WHERE value ${"$"}{ if (oldValue == null) "IS" else "=" } ?2""${'"'}, 2) {
       |        bindString(1, if (newValue == null) null else database.dataAdapter.valueAdapter.encode(newValue))
       |        bindString(2, if (oldValue == null) null else database.dataAdapter.valueAdapter.encode(oldValue))
       |    }
@@ -162,10 +149,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(data: com.example.Data) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?, ?)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?, ?)""${'"'}, 2) {
       |        bindLong(1, data.id)
       |        bindString(2, if (data.value == null) null else database.dataAdapter.valueAdapter.encode(data.value!!))
       |    }
@@ -190,10 +174,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(data: com.example.Data) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data (id)
-      |    |VALUES (?)
-      |    ""${'"'}.trimMargin(), 1) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data (id) VALUES (?)""${'"'}, 1) {
       |        bindLong(1, data.id)
       |    }
       |}
@@ -217,10 +198,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(id: kotlin.Long?) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data (id)
-      |    |VALUES (?1)
-      |    ""${'"'}.trimMargin(), 1) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data (id) VALUES (?1)""${'"'}, 1) {
       |        bindLong(1, id)
       |    }
       |}
@@ -245,11 +223,7 @@ class MutatorQueryFunctionTest {
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun updateData(value: kotlin.collections.List?, id: kotlin.collections.Collection<kotlin.Long>) {
       |    val idIndexes = createArguments(count = id.size, offset = 2)
-      |    driver.execute(null, ""${'"'}
-      |    |UPDATE data
-      |    |SET value = ?1
-      |    |WHERE id IN ${"$"}idIndexes
-      |    ""${'"'}.trimMargin(), 1 + id.size) {
+      |    driver.execute(null, ""${'"'}UPDATE data SET value = ?1 WHERE id IN ${"$"}idIndexes""${'"'}, 1 + id.size) {
       |        bindString(1, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |        id.forEachIndexed { index, id ->
       |                bindLong(index + 2, id)
@@ -278,13 +252,7 @@ class MutatorQueryFunctionTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun updateWithInnerSelect(some_column: kotlin.Long?) {
-      |    driver.execute(${update.id}, ""${'"'}
-      |    |UPDATE some_table
-      |    |SET some_column = (
-      |    |  SELECT CASE WHEN ?1 IS NULL THEN some_column ELSE ?1 END
-      |    |  FROM some_table
-      |    |)
-      |    ""${'"'}.trimMargin(), 1) {
+      |    driver.execute(-828962010, ""${'"'}UPDATE some_table SET some_column = (SELECT CASE WHEN ?1 IS NULL THEN some_column ELSE ?1 END FROM some_table)""${'"'}, 1) {
       |        bindLong(1, some_column)
       |    }
       |}
@@ -319,13 +287,7 @@ class MutatorQueryFunctionTest {
       |    c: kotlin.collections.List<kotlin.String>?,
       |    d: kotlin.collections.List<kotlin.String>?
       |) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |UPDATE paymentHistoryConfig
-      |    |SET a = ?1,
-      |    |    b = ?2,
-      |    |    c = ?3,
-      |    |    d = ?4
-      |    ""${'"'}.trimMargin(), 4) {
+      |    driver.execute(${mutator.id}, ""${'"'}UPDATE paymentHistoryConfig SET a = ?1, b = ?2, c = ?3, d = ?4""${'"'}, 4) {
       |        bindString(1, a)
       |        bindString(2, b)
       |        bindBytes(3, if (c == null) null else database.paymentHistoryConfigAdapter.cAdapter.encode(c))

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -27,10 +27,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?1, ?2)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |        bindLong(1, if (id == null) null else id.toLong())
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
@@ -69,13 +66,7 @@ class MutatorQueryTypeTest {
       |    deprecated: kotlin.Boolean,
       |    link: kotlin.String
       |) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |UPDATE item
-      |    |SET deprecated = ?3,
-      |    |    link = ?4
-      |    |WHERE packageName = ?1
-      |    |  AND className = ?2
-      |    ""${'"'}.trimMargin(), 4) {
+      |    driver.execute(${mutator.id}, ""${'"'}UPDATE item SET deprecated = ?3, link = ?4 WHERE packageName = ?1 AND className = ?2""${'"'}, 4) {
       |        bindLong(3, if (deprecated) 1L else 0L)
       |        bindString(4, link)
       |        bindString(1, packageName)
@@ -107,10 +98,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?1, ?2)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |        bindLong(1, if (id == null) null else id.toLong())
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
@@ -143,10 +131,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?1, ?2)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |        bindLong(1, if (id == null) null else id.toLong())
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
@@ -188,10 +173,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?1, ?2)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |        bindLong(1, if (id == null) null else id.toLong())
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
@@ -216,10 +198,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(id: kotlin.Int?, value: kotlin.collections.List<kotlin.String>?) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?1, ?2)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |        bindLong(1, if (id == null) null else id.toLong())
       |        bindString(2, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
       |    }
@@ -255,16 +234,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun deleteData() {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |DELETE FROM data
-      |    |WHERE id = 1
-      |    |AND value IN (
-      |    |  SELECT data.value
-      |    |  FROM data
-      |    |  INNER JOIN data AS data2
-      |    |  ON data.id = data2.id
-      |    |)
-      |    ""${'"'}.trimMargin(), 0)
+      |    driver.execute(${mutator.id}, ""${'"'}DELETE FROM data WHERE id = 1 AND value IN (SELECT data.value FROM data INNER JOIN data AS data2 ON data.id = data2.id)""${'"'}, 0)
       |    notifyQueries(${mutator.id}, {database.dataQueries.selectForId})
       |}
       |""".trimMargin())
@@ -287,10 +257,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(value: kotlin.Boolean) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data (value)
-      |    |VALUES (?1)
-      |    ""${'"'}.trimMargin(), 1) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data (value) VALUES (?1)""${'"'}, 1) {
       |        bindString(1, if (value) 1L else 0L)
       |    }
       |}
@@ -314,10 +281,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(value: kotlin.ByteArray) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data (value)
-      |    |VALUES (?1)
-      |    ""${'"'}.trimMargin(), 1) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data (value) VALUES (?1)""${'"'}, 1) {
       |        bindBytes(1, value)
       |    }
       |}
@@ -341,10 +305,7 @@ class MutatorQueryTypeTest {
 
     assertThat(generator.function().toString()).isEqualTo("""
       |override fun insertData(value: kotlin.Double) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data (value)
-      |    |VALUES (?1)
-      |    ""${'"'}.trimMargin(), 1) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data (value) VALUES (?1)""${'"'}, 1) {
       |        bindDouble(1, value)
       |    }
       |}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -131,10 +131,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun <T : kotlin.Any> selectForId(mapper: (id: kotlin.Long, value: kotlin.collections.List) -> T): com.squareup.sqldelight.Query<T> = com.squareup.sqldelight.Query(${query.id}, selectForId, driver, "Test.sq", "selectForId", ""${'"'}
-      ||SELECT *
-      ||FROM data
-      |""${'"'}.trimMargin()) { cursor ->
+      |override fun <T : kotlin.Any> selectForId(mapper: (id: kotlin.Long, value: kotlin.collections.List) -> T): com.squareup.sqldelight.Query<T> = com.squareup.sqldelight.Query(${query.id}, selectForId, driver, "Test.sq", "selectForId", "SELECT * FROM data") { cursor ->
       |    mapper(
       |        cursor.getLong(0)!!,
       |        database.dataAdapter.valueAdapter.decode(cursor.getString(1)!!)
@@ -160,13 +157,10 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.Long> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", ""${'"'}
-      ||SELECT *
-      ||FROM data
-      |""${'"'}.trimMargin()) { cursor ->
-      |    cursor.getLong(0)!!
-      |}
-      |
+        |override fun selectData(): com.squareup.sqldelight.Query<kotlin.Long> = com.squareup.sqldelight.Query(-979711549, selectData, driver, "Test.sq", "selectData", "SELECT * FROM data") { cursor ->
+        |    cursor.getLong(0)!!
+        |}
+        |
       """.trimMargin())
   }
 
@@ -192,11 +186,7 @@ class SelectQueryFunctionTest {
       |    override fun execute(): com.squareup.sqldelight.db.SqlCursor {
       |        val goodIndexes = createArguments(count = good.size, offset = 1)
       |        val badIndexes = createArguments(count = bad.size, offset = good.size + 1)
-      |        return driver.executeQuery(null, ""${'"'}
-      |        |SELECT *
-      |        |FROM data
-      |        |WHERE id IN ${"$"}goodIndexes AND id NOT IN ${"$"}badIndexes
-      |        ""${'"'}.trimMargin(), good.size + bad.size) {
+      |        return driver.executeQuery(null, ""${'"'}SELECT * FROM data WHERE id IN ${"$"}goodIndexes AND id NOT IN ${"$"}badIndexes""${'"'}, good.size + bad.size) {
       |            good.forEachIndexed { index, good ->
       |                    bindLong(index + 1, good)
       |                    }
@@ -249,10 +239,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun <T : kotlin.Any> selectData(mapper: (id: kotlin.Long, value: kotlin.Boolean?) -> T): com.squareup.sqldelight.Query<T> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", ""${'"'}
-      ||SELECT *
-      ||FROM data
-      |""${'"'}.trimMargin()) { cursor ->
+override fun <T : kotlin.Any> selectData(mapper: (id: kotlin.Long, value: kotlin.Boolean?) -> T): com.squareup.sqldelight.Query<T> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", "SELECT * FROM data") { cursor ->
       |    mapper(
       |        cursor.getLong(0)!!,
       |        cursor.getLong(1)?.let { it == 1L }
@@ -282,11 +269,7 @@ class SelectQueryFunctionTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class EquivalentNamesNamed<out T : kotlin.Any>(private val name: kotlin.String, mapper: (com.squareup.sqldelight.db.SqlCursor) -> T) : com.squareup.sqldelight.Query<T>(equivalentNamesNamed, mapper) {
-      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}
-      |    |SELECT *
-      |    |FROM person
-      |    |WHERE first_name = ?1 AND last_name = ?1
-      |    ""${'"'}.trimMargin(), 1) {
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}SELECT * FROM person WHERE first_name = ?1 AND last_name = ?1""${'"'}, 1) {
       |        bindString(1, name)
       |    }
       |
@@ -311,10 +294,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.Double> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", ""${'"'}
-      ||SELECT *
-      ||FROM data
-      |""${'"'}.trimMargin()) { cursor ->
+      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.Double> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", "SELECT * FROM data") { cursor ->
       |    cursor.getDouble(0)!!
       |}
       |
@@ -336,10 +316,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.ByteArray> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", ""${'"'}
-      ||SELECT *
-      ||FROM data
-      |""${'"'}.trimMargin()) { cursor ->
+      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.ByteArray> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", "SELECT * FROM data") { cursor ->
       |    cursor.getBytes(0)!!
       |}
       |
@@ -380,10 +357,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.Boolean> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", ""${'"'}
-      ||SELECT *
-      ||FROM data
-      |""${'"'}.trimMargin()) { cursor ->
+      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.Boolean> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", "SELECT * FROM data") { cursor ->
       |    cursor.getLong(0)!! == 1L
       |}
       |
@@ -405,10 +379,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.Int> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", ""${'"'}
-      ||SELECT *
-      ||FROM data
-      |""${'"'}.trimMargin()) { cursor ->
+      |override fun selectData(): com.squareup.sqldelight.Query<kotlin.Int> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", "SELECT * FROM data") { cursor ->
       |    cursor.getLong(0)!!.toInt()
       |}
       |
@@ -430,10 +401,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun <T : kotlin.Any> selectData(mapper: (value: kotlin.Int?) -> T): com.squareup.sqldelight.Query<T> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", ""${'"'}
-      ||SELECT *
-      ||FROM data
-      |""${'"'}.trimMargin()) { cursor ->
+      |override fun <T : kotlin.Any> selectData(mapper: (value: kotlin.Int?) -> T): com.squareup.sqldelight.Query<T> = com.squareup.sqldelight.Query(${query.id}, selectData, driver, "Test.sq", "selectData", "SELECT * FROM data") { cursor ->
       |    mapper(
       |        cursor.getLong(0)?.toInt()
       |    )
@@ -531,10 +499,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(query)
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun select(): com.squareup.sqldelight.Query<com.example.BigTable> = com.squareup.sqldelight.Query(${query.id}, select, driver, "Test.sq", "select", ""${'"'}
-      ||SELECT *
-      ||FROM bigTable
-      |""${'"'}.trimMargin()) { cursor ->
+      |override fun select(): com.squareup.sqldelight.Query<com.example.BigTable> = com.squareup.sqldelight.Query(${query.id}, select, driver, "Test.sq", "select", "SELECT * FROM bigTable") { cursor ->
       |    com.example.BigTable.Impl(
       |        cursor.getLong(0),
       |        cursor.getLong(1),
@@ -669,20 +634,7 @@ class SelectQueryFunctionTest {
       |    status: Test.Status?,
       |    attr: kotlin.String?,
       |    ordering: kotlin.Long
-      |) -> T): com.squareup.sqldelight.Query<T> = com.squareup.sqldelight.Query(${query.id}, someSelect, driver, "Test.sq", "someSelect", ""${'"'}
-      ||SELECT *
-      ||FROM (
-      ||  SELECT *, 1 AS ordering
-      ||  FROM testA
-      ||  WHERE testA.attr IS NOT NULL
-      ||
-      ||  UNION
-      ||
-      ||  SELECT *, 2 AS ordering
-      ||         FROM testA
-      ||  WHERE testA.attr IS NULL
-      ||)
-      |""${'"'}.trimMargin()) { cursor ->
+      |) -> T): com.squareup.sqldelight.Query<T> = com.squareup.sqldelight.Query(${query.id}, someSelect, driver, "Test.sq", "someSelect", "SELECT * FROM (SELECT *, 1 AS ordering FROM testA WHERE testA.attr IS NOT NULL UNION SELECT *, 2 AS ordering FROM testA WHERE testA.attr IS NULL)") { cursor ->
       |    mapper(
       |        cursor.getString(0)!!,
       |        cursor.getString(1)?.let(database.testAAdapter.statusAdapter::decode),
@@ -769,10 +721,7 @@ class SelectQueryFunctionTest {
     val query = file.namedQueries.first()
     val generator = SelectQueryGenerator(query)
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo("""
-      |override fun someSelect(): com.squareup.sqldelight.Query<kotlin.Double> = com.squareup.sqldelight.Query(${query.id}, someSelect, driver, "Test.sq", "someSelect", ""${'"'}
-      ||SELECT SUM(stuff) / 3.0
-      ||FROM test
-      |""${'"'}.trimMargin()) { cursor ->
+      |override fun someSelect(): com.squareup.sqldelight.Query<kotlin.Double> = com.squareup.sqldelight.Query(${query.id}, someSelect, driver, "Test.sq", "someSelect", "SELECT SUM(stuff) / 3.0 FROM test") { cursor ->
       |    cursor.getDouble(0)!!
       |}
       |

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -27,11 +27,7 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class SelectForId<out T : kotlin.Any>(private val id: kotlin.Long, mapper: (com.squareup.sqldelight.db.SqlCursor) -> T) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
-      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}
-      |    |SELECT *
-      |    |FROM data
-      |    |WHERE id = ?1
-      |    ""${'"'}.trimMargin(), 1) {
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}SELECT * FROM data WHERE id = ?1""${'"'}, 1) {
       |        bindLong(1, id)
       |    }
       |
@@ -63,12 +59,7 @@ class SelectQueryTypeTest {
       |    private val id: kotlin.Long,
       |    mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(select, mapper) {
-      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}
-      |    |SELECT *
-      |    |FROM data
-      |    |WHERE id = ?2
-      |    |AND value = ?1
-      |    ""${'"'}.trimMargin(), 2) {
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}SELECT * FROM data WHERE id = ?2 AND value = ?1""${'"'}, 2) {
       |        bindLong(2, id)
       |        bindString(1, value)
       |    }
@@ -96,11 +87,7 @@ class SelectQueryTypeTest {
       |private inner class SelectForId<out T : kotlin.Any>(private val id: kotlin.collections.Collection<kotlin.Long>, mapper: (com.squareup.sqldelight.db.SqlCursor) -> T) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
       |    override fun execute(): com.squareup.sqldelight.db.SqlCursor {
       |        val idIndexes = createArguments(count = id.size, offset = 1)
-      |        return driver.executeQuery(null, ""${'"'}
-      |        |SELECT *
-      |        |FROM data
-      |        |WHERE id IN ${"$"}idIndexes
-      |        ""${'"'}.trimMargin(), id.size) {
+      |        return driver.executeQuery(null, ""${'"'}SELECT * FROM data WHERE id IN ${"$"}idIndexes""${'"'}, id.size) {
       |            id.forEachIndexed { index, id ->
       |                    bindLong(index + 1, id)
       |                    }
@@ -161,11 +148,7 @@ class SelectQueryTypeTest {
        |    private val username: kotlin.String,
        |    mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
        |) : com.squareup.sqldelight.Query<T>(selectData, mapper) {
-       |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(null, ""${'"'}
-       |    |SELECT _id, username
-       |    |FROM Friend
-       |    |WHERE userId${'$'}{ if (userId == null) " IS " else "=" }?1 OR username=?2 LIMIT 2
-       |    ""${'"'}.trimMargin(), 2) {
+       |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(null, ""${'"'}SELECT _id, username FROM Friend WHERE userId${"$"}{ if (userId == null) " IS " else "=" }?1 OR username=?2 LIMIT 2""${'"'}, 2) {
        |        bindString(1, userId)
        |        bindString(2, username)
        |    }
@@ -202,14 +185,7 @@ class SelectQueryTypeTest {
       |    private val val____: kotlin.String?,
       |    mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
-      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(null, ""${'"'}
-      |    |SELECT *
-      |    |FROM data
-      |    |WHERE val ${"$"}{ if (val_ == null) "IS" else "=" } ?1
-      |    |AND val ${"$"}{ if (val__ == null) "IS" else "==" } ?2
-      |    |AND val ${"$"}{ if (val___ == null) "IS NOT" else "<>" } ?3
-      |    |AND val ${"$"}{ if (val____ == null) "IS NOT" else "!=" } ?4
-      |    ""${'"'}.trimMargin(), 4) {
+      |    override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(null, ""${'"'}SELECT * FROM data WHERE val ${"$"}{ if (val_ == null) "IS" else "=" } ?1 AND val ${"$"}{ if (val__ == null) "IS" else "==" } ?2 AND val ${'$'}{ if (val___ == null) "IS NOT" else "<>" } ?3 AND val ${"$"}{ if (val____ == null) "IS NOT" else "!=" } ?4""${'"'}, 4) {
       |        bindString(1, val_)
       |        bindString(2, val__)
       |        bindString(3, val___)

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/triggers/TriggerNotificationTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/triggers/TriggerNotificationTest.kt
@@ -43,10 +43,7 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |override fun insertData(id: kotlin.Long?, value: kotlin.String?) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |INSERT INTO data
-      |    |VALUES (?1, ?2)
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}INSERT INTO data VALUES (?1, ?2)""${'"'}, 2) {
       |        bindLong(1, id)
       |        bindString(2, value)
       |    }
@@ -88,10 +85,7 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |override fun deleteData(id: kotlin.Long) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |DELETE FROM data
-      |    |WHERE id = ?1
-      |    ""${'"'}.trimMargin(), 1) {
+      |    driver.execute(${mutator.id}, ""${'"'}DELETE FROM data WHERE id = ?1""${'"'}, 1) {
       |        bindLong(1, id)
       |    }
       |}
@@ -132,11 +126,7 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |override fun deleteData(value: kotlin.String?, id: kotlin.Long) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |UPDATE data
-      |    |SET value = ?1
-      |    |WHERE id = ?2
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}UPDATE data SET value = ?1 WHERE id = ?2""${'"'}, 2) {
       |        bindString(1, value)
       |        bindLong(2, id)
       |    }
@@ -178,11 +168,7 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |override fun deleteData(value: kotlin.String?, id: kotlin.Long) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |UPDATE data
-      |    |SET value = ?1
-      |    |WHERE id = ?2
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}UPDATE data SET value = ?1 WHERE id = ?2""${'"'}, 2) {
       |        bindString(1, value)
       |        bindLong(2, id)
       |    }
@@ -225,11 +211,7 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |override fun deleteData(value: kotlin.String?, id: kotlin.Long) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |UPDATE data
-      |    |SET value = ?1
-      |    |WHERE id = ?2
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}UPDATE data SET value = ?1 WHERE id = ?2""${'"'}, 2) {
       |        bindString(1, value)
       |        bindLong(2, id)
       |    }
@@ -272,11 +254,7 @@ class MutatorQueryFunctionTest {
     Truth.assertThat(generator.function().toString())
         .isEqualTo("""
       |override fun deleteData(value: kotlin.String?, id: kotlin.Long) {
-      |    driver.execute(${mutator.id}, ""${'"'}
-      |    |UPDATE data
-      |    |SET value = ?1
-      |    |WHERE id = ?2
-      |    ""${'"'}.trimMargin(), 2) {
+      |    driver.execute(${mutator.id}, ""${'"'}UPDATE data SET value = ?1 WHERE id = ?2""${'"'}, 2) {
       |        bindString(1, value)
       |        bindLong(2, id)
       |    }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/util/TreeUtilTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/util/TreeUtilTest.kt
@@ -1,6 +1,7 @@
 package com.squareup.sqldelight.core.util
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.sqldelight.core.lang.util.optimizeRawSqlText
 import com.squareup.sqldelight.core.lang.util.rawSqlText
 import com.squareup.sqldelight.test.util.FixtureCompiler
 import org.junit.Rule
@@ -21,13 +22,7 @@ class TreeUtilTest {
 
     val createTable = file.sqliteStatements().first().statement.createTableStmt!!
 
-    assertThat(createTable.rawSqlText()).isEqualTo("""
-      |CREATE TABLE test (
-      |  value TEXT,
-      |  other_value TEXT,
-      |  a_third_value INTEGER DEFAULT 0
-      |)
-    """.trimMargin())
+    assertThat(createTable.rawSqlText()).isEqualTo("CREATE TABLE test (value TEXT, other_value TEXT, a_third_value INTEGER DEFAULT 0)")
   }
 
   @Test fun `rawSqlText replaces insert bind param with columns being inserted`() {
@@ -47,16 +42,25 @@ class TreeUtilTest {
 
     val insert1 = file.sqliteStatements().elementAt(1).statement.insertStmt!!
 
-    assertThat(insert1.rawSqlText()).isEqualTo("""
-      |INSERT INTO test (value, other_value)
-      |VALUES (?, ?)
-    """.trimMargin())
+    assertThat(insert1.rawSqlText()).isEqualTo("INSERT INTO test (value, other_value) VALUES (?, ?)")
 
     val insert2 = file.sqliteStatements().elementAt(2).statement.insertStmt!!
 
-    assertThat(insert2.rawSqlText()).isEqualTo("""
-      |INSERT INTO test
-      |VALUES (?, ?, ?)
-    """.trimMargin())
+    assertThat(insert2.rawSqlText()).isEqualTo("INSERT INTO test VALUES (?, ?, ?)")
   }
+
+    @Test fun `optimizeRawSqlText removes comments and extra whitespace`() {
+        val createStatement = """
+          |CREATE TABLE test (
+          |  -- hello world
+          |  value TEXT AS kotlin.collections.List<Int>,
+          |  other_value TEXT AS Int,
+          |  a_third_value INTEGER AS Boolean DEFAULT 0 -- inlined comment
+          |  -- another comment
+          |);
+        """.trimMargin()
+
+        assertThat(optimizeRawSqlText(createStatement)).isEqualTo("CREATE TABLE test (value TEXT AS kotlin.collections.List<Int>, other_value TEXT AS Int, a_third_value INTEGER AS Boolean DEFAULT 0);")
+
+    }
 }


### PR DESCRIPTION
**Background**
I noticed `trimMargin` doesn't remove the extra whitespace inserted between lines (`'\n      ` after every newline) and comments were still included in raw sql text

**Change**
Optimize the raw sql text to strip out extraneous whitespace and comments

**Test Plan**
Updated test suite and ran