### PR TITLE
Defer creation of install* Gradle tasks, fixing Linux clean build

### DIFF
--- a/drivers/ios-driver/build.gradle
+++ b/drivers/ios-driver/build.gradle
@@ -67,8 +67,10 @@ publishing {
 
 afterEvaluate {
   // Alias the task names we use elsewhere to the new task names.
-  tasks.create('install').dependsOn('publishKotlinMultiplatformPublicationToMavenLocal')
-  tasks.create('installLocally') {
+  tasks.register('install') {
+    dependsOn('publishKotlinMultiplatformPublicationToMavenLocal')
+  }
+  tasks.register('installLocally') {
     dependsOn 'publishMetadataPublicationToTestRepository'
     dependsOn 'publishKotlinMultiplatformPublicationToTestRepository'
     dependsOn 'publishIosX64PublicationToTestRepository'
@@ -76,5 +78,5 @@ afterEvaluate {
     dependsOn 'publishIosArm64PublicationToTestRepository'
   }
   // NOTE: We do not alias uploadArchives because CI runs it on Linux and we only want to run it on Mac OS.
-  //tasks.create('uploadArchives').dependsOn('publishKotlinMultiplatformPublicationToMavenRepository')
+  //tasks.register('uploadArchives').dependsOn('publishKotlinMultiplatformPublicationToMavenRepository')
 }

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -77,8 +77,12 @@ kotlin {
 apply from: "$rootDir/gradle/gradle-mvn-mpp-push.gradle"
 
 afterEvaluate {
-  tasks.create('install').dependsOn('publishToMavenLocal')
-  tasks.create('installLocally').dependsOn('publishAllPublicationsToTestRepository')
+  tasks.register('install') {
+    dependsOn('publishToMavenLocal')
+  }
+  tasks.register('installLocally') {
+    dependsOn('publishAllPublicationsToTestRepository')
+  }
   // NOTE: We do not alias uploadArchives because CI runs it on Linux and we only want to run it on Mac OS.
-  //tasks.create('uploadArchives').dependsOn('publishAllPublicationsToMavenRepository')
+  //tasks.register('uploadArchives').dependsOn('publishAllPublicationsToMavenRepository')
 }

--- a/sqldelight-runtime/build.gradle
+++ b/sqldelight-runtime/build.gradle
@@ -68,14 +68,16 @@ kotlin {
 
 afterEvaluate {
   // Alias the task names we use elsewhere to the new task names.
-  tasks.create('install').dependsOn('publishKotlinMultiplatformPublicationToMavenLocal')
-  tasks.create('installLocally') {
+  tasks.register('install') {
+    dependsOn('publishKotlinMultiplatformPublicationToMavenLocal')
+  }
+  tasks.register('installLocally') {
     dependsOn 'publishKotlinMultiplatformPublicationToTestRepository'
     dependsOn 'publishJvmPublicationToTestRepository'
     dependsOn 'publishJsPublicationToTestRepository'
     dependsOn 'publishMetadataPublicationToTestRepository'
   }
-  tasks.create('installIosLocally') {
+  tasks.register('installIosLocally') {
     dependsOn 'publishKotlinMultiplatformPublicationToTestRepository'
     dependsOn 'publishIosArm32PublicationToTestRepository'
     dependsOn 'publishIosArm64PublicationToTestRepository'
@@ -83,7 +85,7 @@ afterEvaluate {
     dependsOn 'publishMetadataPublicationToTestRepository'
   }
   // NOTE: We do not alias uploadArchives because CI runs it on Linux and we only want to run it on Mac OS.
-  //tasks.create('uploadArchives').dependsOn('publishKotlinMultiplatformPublicationToMavenRepository')
+  //tasks.register('uploadArchives').dependsOn('publishKotlinMultiplatformPublicationToMavenRepository')
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-mpp-push.gradle"


### PR DESCRIPTION
A clean checkout of master @ b07dace1d08e1e09e259edf370fd7390be00eb3d doesn't build (or even configure) on Linux for me. For example on my Linux computer `./gradlew tasks` fails with:
```
Could not determine the dependencies of task ':drivers:ios-driver:installLocally'.
> Task with path 'publishIosX64PublicationToTestRepository' not found in project ':drivers:ios-driver'.
```

These changes defer creation of the various `publish*` tasks so that they are not created during the configuration phase and so don't need to exist if they aren't used in the build. This is also in line with [Gradle's documentation](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:how_do_i_defer_creation) recommending configuration avoidance APIs be used.

As a side note, I'm not sure what difference makes the CI Linux builds succeed, but not the build on my computer. Perhaps something about the task configuration is being cached as part of the CI caching `~/.gradle/caches`. 