### PR TITLE
Give VerifyMigration task its own output directory #1380

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -20,8 +20,8 @@ class SqlDelightDatabase(
   var schemaOutputDirectory: File? = null,
   var sourceFolders: Collection<String>? = null
 ) {
-  private val outputDirectory
-    get() = File(project.buildDir, "sqldelight/$name")
+  private val generatedSourcesDirectory
+    get() = File(project.buildDir, "sqldelight/code/$name")
 
   private val sources by lazy { sources() }
   private val dependencies = mutableListOf<SqlDelightDatabase>()
@@ -62,7 +62,7 @@ class SqlDelightDatabase(
                 sourceFolders = sourceFolders(source).sortedBy { it.path }
             )
           },
-          outputDirectory = outputDirectory.toRelativeString(project.projectDir),
+          outputDirectory = generatedSourcesDirectory.toRelativeString(project.projectDir),
           className = name,
           dependencies = dependencies.map { SqlDelightDatabaseName(it.packageName!!, it.name) }
       )
@@ -96,12 +96,12 @@ class SqlDelightDatabase(
     // place right now. Can revisit later but prioritise common for now:
 
     val common = sources.singleOrNull { it.type == KotlinPlatformType.common }
-    common?.sourceDirectorySet?.srcDir(outputDirectory.toRelativeString(project.projectDir))
+    common?.sourceDirectorySet?.srcDir(generatedSourcesDirectory.toRelativeString(project.projectDir))
 
     sources.forEach { source ->
       // Add the source dependency on the generated code.
       if (common == null) {
-        source.sourceDirectorySet.srcDir(outputDirectory.toRelativeString(project.projectDir))
+        source.sourceDirectorySet.srcDir(generatedSourcesDirectory.toRelativeString(project.projectDir))
       }
 
       val allFiles = sourceFolders(source)
@@ -113,7 +113,7 @@ class SqlDelightDatabase(
         it.properties = getProperties()
         it.sourceFolders = sourceFiles.files
         it.dependencySourceFolders = dependencyFiles.files
-        it.outputDirectory = outputDirectory
+        it.outputDirectory = generatedSourcesDirectory
         it.source(sourceFiles + dependencyFiles)
         it.include("**${File.separatorChar}*.${SqlDelightFileType.defaultExtension}")
         it.include("**${File.separatorChar}*.${MigrationFileType.defaultExtension}")

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -138,6 +138,7 @@ class SqlDelightDatabase(
           it.source(sourceSet)
           it.include("**${File.separatorChar}*.${SqlDelightFileType.defaultExtension}")
           it.include("**${File.separatorChar}*.${MigrationFileType.defaultExtension}")
+          it.workingDirectory = File(project.buildDir, "sqldelight/migration_verification/${source.name.capitalize()}$name")
           it.group = "sqldelight"
           it.description = "Verify ${source.name} $name migrations and CREATE statements match."
         }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
@@ -29,7 +29,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "main",
@@ -66,7 +66,7 @@ class CompilationUnitTests {
             SqlDelightDatabaseProperties(
                 className = "CommonDb",
                 packageName = "com.sample",
-                outputDirectory = "build/sqldelight/CommonDb",
+                outputDirectory = "build/sqldelight/code/CommonDb",
                 compilationUnits = listOf(
                     SqlDelightCompilationUnit(
                         name = "main",
@@ -78,7 +78,7 @@ class CompilationUnitTests {
             SqlDelightDatabaseProperties(
                 className = "OtherDb",
                 packageName = "com.sample.otherdb",
-                outputDirectory = "build/sqldelight/OtherDb",
+                outputDirectory = "build/sqldelight/code/OtherDb",
                 compilationUnits = listOf(
                     SqlDelightCompilationUnit(
                         name = "main",
@@ -125,7 +125,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "jvmMain",
@@ -229,7 +229,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "androidLibMinApi21DemoDebug",
@@ -435,7 +435,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "minApi23DemoDebug",

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
@@ -28,7 +28,7 @@ class MultiModuleTests {
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/Database")
+    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/code/Database")
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
@@ -100,7 +100,7 @@ class MultiModuleTests {
         .withInvariantPathSeparators()
         .withSortedCompilationUnits()
     assertThat(properties.packageName).isEqualTo("com.sample.android")
-    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/CommonDb")
+    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
     assertThat(properties.compilationUnits).containsExactly(
         SqlDelightCompilationUnit(
             name = "minApi23Debug",

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
@@ -25,7 +25,7 @@ class PropertiesFileTest {
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/Database")
+    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/code/Database")
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {


### PR DESCRIPTION
Currently the Gradle task that generates the source code and the VerifyMigration task both share the `build/sqldelight` directory. One of the first things that the VerifyMigration task does is to delete this directory. If a generate interfaces task has run, then that deleted directory contained the generated source code needed to compile the project!

This change avoids clobbering the generated source code generated by changing the VerifyMigration task to use a directory named `build/sqldelight-verifyMigration` instead.

It was certainly unexpected for me to discover that a check task deletes source code generated by an earlier task, so I don't think this was by design. Changing them to use separate directories fixes the racy behavior where the build will succeed or fail determined by the relative ordering of VerifyMigration and compile tasks. See #1380 for an example of this. 