### PR TITLE
Fixed tests failing when run on Windows

### DIFF
--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/errors/ErrorTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/errors/ErrorTest.kt
@@ -1,7 +1,8 @@
-package com.squareup.sqldelight.core.errors;
+package com.squareup.sqldelight.core.errors
 
 import com.google.common.truth.Truth.assertWithMessage
 import com.squareup.sqldelight.test.util.FixtureCompiler
+import com.squareup.sqldelight.test.util.splitLines
 import org.junit.Test
 import java.io.File
 
@@ -16,7 +17,7 @@ class ErrorTest {
     val expectedFailure = File("src/test/errors/$fixtureRoot", "failure.txt")
     if (expectedFailure.exists()) {
       assertWithMessage(result.sourceFiles).that(result.errors).containsExactlyElementsIn(
-          expectedFailure.readText().split("\n").filterNot { it.isEmpty() })
+          expectedFailure.readText().splitLines().filter { it.isNotEmpty() })
     } else {
       assertWithMessage(result.sourceFiles).that(result.errors).isEmpty()
     }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
@@ -1,11 +1,10 @@
 package com.squareup.sqldelight.core.queries
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.kotlinpoet.FileSpec
 import com.squareup.sqldelight.core.compiler.QueryInterfaceGenerator
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler
-import com.squareup.sqldelight.core.compiler.TableInterfaceGenerator
 import com.squareup.sqldelight.test.util.FixtureCompiler
+import com.squareup.sqldelight.test.util.withInvariantLineSeparators
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -673,8 +672,9 @@ class InterfaceGeneration {
         false)
     for ((expectedFile, actualOutput) in result.compilerOutput) {
       assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
-      assertThat(expectedFile.readText()).named(expectedFile.name).isEqualTo(
-          actualOutput.toString())
+      assertThat(expectedFile.readText().withInvariantLineSeparators())
+          .named(expectedFile.name)
+          .isEqualTo(actualOutput.toString())
     }
   }
 }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler
 import com.squareup.sqldelight.core.compiler.TableInterfaceGenerator
 import com.squareup.sqldelight.test.util.FixtureCompiler
+import com.squareup.sqldelight.test.util.withInvariantLineSeparators
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -374,8 +375,9 @@ class InterfaceGeneration {
         false)
     for ((expectedFile, actualOutput) in result.compilerOutput) {
       assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
-      assertThat(expectedFile.readText()).named(expectedFile.name).isEqualTo(
-          actualOutput.toString())
+      assertThat(expectedFile.readText().withInvariantLineSeparators())
+          .named(expectedFile.name)
+          .isEqualTo(actualOutput.toString())
     }
   }
 }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
@@ -3,6 +3,7 @@ package com.squareup.sqldelight.core.views
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler
 import com.squareup.sqldelight.test.util.FixtureCompiler
+import com.squareup.sqldelight.test.util.withInvariantLineSeparators
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -207,8 +208,9 @@ class InterfaceGeneration {
         false)
     for ((expectedFile, actualOutput) in result.compilerOutput) {
       assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
-      assertThat(expectedFile.readText()).named(expectedFile.name).isEqualTo(
-          actualOutput.toString())
+      assertThat(expectedFile.readText().withInvariantLineSeparators())
+          .named(expectedFile.name)
+          .isEqualTo(actualOutput.toString())
     }
   }
 }

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -69,12 +69,9 @@ test {
             ":sqldelight-runtime:installLocally",
             ":drivers:android-driver:installLocally",
             ":drivers:sqlite-driver:installLocally",
-//            ":sqldelight-runtime:installIosLocally",
-//            ":drivers:ios-driver:installLocally",
+            ":sqldelight-runtime:installIosLocally",
+            ":drivers:ios-driver:installLocally",
     )
-    useJUnit {
-      excludeCategories 'com.squareup.sqldelight.IosTest'
-    }
   }
 }
 

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
   testImplementation deps.junit
   testImplementation deps.truth
+  testImplementation project(':test-util')
 
   bundled deps.intellijCore
 

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 
   testImplementation deps.junit
   testImplementation deps.truth
-  testImplementation project(':test-util')
 
   bundled deps.intellijCore
 
@@ -70,9 +69,12 @@ test {
             ":sqldelight-runtime:installLocally",
             ":drivers:android-driver:installLocally",
             ":drivers:sqlite-driver:installLocally",
-            ":sqldelight-runtime:installIosLocally",
-            ":drivers:ios-driver:installLocally",
+//            ":sqldelight-runtime:installIosLocally",
+//            ":drivers:ios-driver:installLocally",
     )
+    useJUnit {
+      excludeCategories 'com.squareup.sqldelight.IosTest'
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/AndroidTestUtil.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/AndroidTestUtil.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.sqldelight
 
+import com.squareup.sqldelight.test.util.withInvariantPathSeparators
 import java.io.File
 import java.util.Properties
 
@@ -22,7 +23,7 @@ import java.util.Properties
 internal fun androidHome(): String {
   val env = System.getenv("ANDROID_HOME")
   if (env != null) {
-    return env
+    return env.withInvariantPathSeparators()
   }
   val localProp = File(File(System.getProperty("user.dir")).parentFile, "local.properties")
   if (localProp.exists()) {
@@ -32,7 +33,7 @@ internal fun androidHome(): String {
     }
     val sdkHome = prop.getProperty("sdk.dir")
     if (sdkHome != null) {
-      return sdkHome
+      return sdkHome.withInvariantPathSeparators()
     }
   }
   throw IllegalStateException(

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/AndroidTestUtil.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/AndroidTestUtil.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.sqldelight
 
-import com.squareup.sqldelight.test.util.withInvariantPathSeparators
 import java.io.File
 import java.util.Properties
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
@@ -26,7 +26,7 @@ class MultiModuleTests {
     val propertiesFile = File(fixtureRoot, ".idea/sqldelight/ProjectA/${SqlDelightPropertiesFile.NAME}")
     assertThat(propertiesFile.exists()).isTrue()
 
-    val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single()
+    val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
     assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/Database")
     assertThat(properties.compilationUnits).hasSize(1)
@@ -97,6 +97,8 @@ class MultiModuleTests {
     assertThat(propertiesFile.exists()).isTrue()
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single()
+        .withInvariantPathSeparators()
+        .withSortedCompilationUnits()
     assertThat(properties.packageName).isEqualTo("com.sample.android")
     assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/CommonDb")
     assertThat(properties.compilationUnits).containsExactly(

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
@@ -23,7 +23,7 @@ class PropertiesFileTest {
     val propertiesFile = File(fixtureRoot, ".idea/sqldelight/${SqlDelightPropertiesFile.NAME}")
     assertThat(propertiesFile.exists()).isTrue()
 
-    val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single()
+    val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
     assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/Database")
     assertThat(properties.compilationUnits).hasSize(1)

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
@@ -36,7 +36,7 @@ internal class TemporaryFixture : AutoCloseable {
     configure()
     return SqlDelightPropertiesFile.fromFile(
         file = File(ideaDirectory, "sqldelight/${SqlDelightPropertiesFile.NAME}")
-    )
+    ).withInvariantPathSeparators()
   }
 
   override fun close() {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
@@ -1,0 +1,36 @@
+package com.squareup.sqldelight
+
+import com.squareup.sqldelight.core.SqlDelightCompilationUnit
+import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
+import com.squareup.sqldelight.core.SqlDelightPropertiesFile
+import com.squareup.sqldelight.core.SqlDelightSourceFolder
+import com.squareup.sqldelight.test.util.withInvariantPathSeparators
+
+internal fun SqlDelightPropertiesFile.withInvariantPathSeparators(): SqlDelightPropertiesFile {
+  return SqlDelightPropertiesFile(
+      databases = databases.map { it.withInvariantPathSeparators() }
+  )
+}
+
+internal fun SqlDelightDatabaseProperties.withInvariantPathSeparators(): SqlDelightDatabaseProperties {
+  return copy(
+      compilationUnits = compilationUnits.map { it.withInvariantPathSeparators() },
+      outputDirectory = outputDirectory.withInvariantPathSeparators()
+  )
+}
+
+internal fun SqlDelightDatabaseProperties.withSortedCompilationUnits(): SqlDelightDatabaseProperties {
+  return copy(
+      compilationUnits = compilationUnits.map { it.withSortedSourceFolders() }
+  )
+}
+
+private fun SqlDelightCompilationUnit.withInvariantPathSeparators(): SqlDelightCompilationUnit {
+  return copy(sourceFolders = sourceFolders.map { it.withInvariantPathSeparators() })
+}
+
+private fun SqlDelightCompilationUnit.withSortedSourceFolders(): SqlDelightCompilationUnit {
+  return copy(sourceFolders = sourceFolders.sortedBy { it.path })
+}
+
+private fun SqlDelightSourceFolder.withInvariantPathSeparators() = copy(path = path.withInvariantPathSeparators())

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
@@ -4,7 +4,8 @@ import com.squareup.sqldelight.core.SqlDelightCompilationUnit
 import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightPropertiesFile
 import com.squareup.sqldelight.core.SqlDelightSourceFolder
-import com.squareup.sqldelight.test.util.withInvariantPathSeparators
+
+internal fun String.withInvariantPathSeparators() = replace("\\", "/")
 
 internal fun SqlDelightPropertiesFile.withInvariantPathSeparators(): SqlDelightPropertiesFile {
   return SqlDelightPropertiesFile(

--- a/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/Extensions.kt
+++ b/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/Extensions.kt
@@ -1,0 +1,5 @@
+package com.squareup.sqldelight.test.util
+
+fun String.withInvariantPathSeparators() = replace("\\", "/")
+fun String.withInvariantLineSeparators() = replace("\r\n", "\n")
+fun String.splitLines() = split("\\r?\\n".toRegex())


### PR DESCRIPTION
The test code doesn't take into account the possibility of different line endings or path separators, resulting in many of the tests failing when run locally on a Windows machine.  While there may not be a Windows CI server, it does make it more difficult for those of us on Windows to verify changes when making contributions to the project.

The changes I've made here ensure that paths and line endings are transformed to an invariant representation before comparison.  In addition to that, I found that the source folders in the SqlDelightPropertiesFile file weren't in exactly the same order, causing failures there too, so I made sure that those are sorted before comparison -- I don't think the order matters there, but correct me if I'm wrong.

Even with these changes, you still need to mess around with the TRAVIS_OS_NAME or modify build.gradle for sqldelight-gradle-plugin in order to get the integration tests to run correctly on a machine that doesn't have both Android and iOs dependencies installed.  I'm not sure if there's a way to determine that automatically based on which targets are configured by Kotlin MPP or it'd require a manual option.  This isn't a problem exclusive to Windows though.