### PR TITLE
Fixed type inference for synthesized columns

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/TreeUtil.kt
@@ -15,7 +15,14 @@
  */
 package com.squareup.sqldelight.core.lang.util
 
-import com.alecstrong.sqlite.psi.core.psi.*
+import com.alecstrong.sqlite.psi.core.psi.AliasElement
+import com.alecstrong.sqlite.psi.core.psi.SqliteColumnName
+import com.alecstrong.sqlite.psi.core.psi.SqliteCreateViewStmt
+import com.alecstrong.sqlite.psi.core.psi.SqliteCreateTableStmt
+import com.alecstrong.sqlite.psi.core.psi.SqliteCreateVirtualTableStmt
+import com.alecstrong.sqlite.psi.core.psi.SqliteExpr
+import com.alecstrong.sqlite.psi.core.psi.SqliteTableName
+import com.alecstrong.sqlite.psi.core.psi.SqliteTypes
 import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.tree.TokenSet

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonMain/sqldelight/com/squareup/sqldelight/integration/FtsTable.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonMain/sqldelight/com/squareup/sqldelight/integration/FtsTable.sq
@@ -1,0 +1,81 @@
+CREATE VIRTUAL TABLE place USING fts3 (
+  tokenize=porter,
+  name TEXT NOT NULL
+);
+
+
+CREATE TABLE book (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  author TEXT NOT NULL,
+  publisher TEXT,
+  yearPublished INTEGER
+);
+
+CREATE VIRTUAL TABLE book_fts USING fts4 (
+  title TEXT NOT NULL,
+  author TEXT NOT NULL,
+  publisher TEXT
+);
+
+CREATE TRIGGER after_book_insert AFTER INSERT ON book
+BEGIN
+    INSERT INTO book_fts (
+        rowid,
+        title,
+        author,
+        publisher
+    ) VALUES (
+        new.id,
+        new.title,
+        new.author,
+        new.publisher
+    );
+END;
+
+CREATE TRIGGER after_book_update AFTER UPDATE ON book
+BEGIN
+    UPDATE book_fts SET
+        title = new.title,
+        author = new.author,
+        publisher = new.publisher
+    WHERE rowid = new.id;
+END;
+
+CREATE TRIGGER after_book_delete AFTER DELETE ON book
+BEGIN
+    DELETE FROM book_fts WHERE rowid = old.id;
+END;
+
+INSERT INTO book (
+    title,
+    author,
+    publisher,
+    yearPublished
+) VALUES
+    ('A Game of Thrones', 'George R. R. Martin', 'Bantam Spectra', 1996),
+    ('My Life Story', 'Me', NULL, NULL);
+
+selectStandalone:
+SELECT * FROM place WHERE place MATCH ?1;
+
+selectJoinedFtsFirst:
+SELECT book.*
+FROM book_fts
+JOIN book ON docid = book.id
+WHERE book_fts MATCH :searchText
+ORDER BY rank(matchinfo(book_fts));
+
+--TODO: Not working yet
+--selectJoinedFtsSecond:
+--SELECT book.*
+--FROM book
+--JOIN book_fts ON docid = book.id
+--WHERE book_fts MATCH :searchText
+--ORDER BY rank(matchinfo(book_fts));
+
+selectNested:
+SELECT * FROM book
+WHERE book.id IN (
+  SELECT docid FROM book_fts WHERE book_fts MATCH :searchText
+);


### PR DESCRIPTION
While looking at the FTS table issue described in #1405, I found that the error described there is actually a more general problem with inferring the type of synthesized columns.  It can be reproduced with simple statements like those below:

```
CREATE TABLE a(id INTEGER NOT NULL PRIMARY KEY);

-- Both fail with 'Failed to compile SqliteCompoundSelectStmtImpl(COMPOUND_SELECT_STMT)'
select:
SELECT * FROM a WHERE rowid = ?;

selectJustRowid:
SELECT rowid FROM a;

```

This pull request adds handling for that case and some additional test coverage around synthesized columns and FTS tables.  The fix here isn't perfect since it forces the use of a String type.  We could hard code a type for each synthesized column into SqlDelight, though it seems a bit hack-ish.  A better solution would probably be to make some changes to the way synthesized columns are dealt with in sqlite-psi, but that seems like it might be more involved.  I figured it'd be good to get some feedback first.

With the changes here, using the MATCH operator on an FTS table becomes usable, at least in basic situations.  There are some additional issues still, which I'll document separately, but one of those involves the order of the FTS table in a JOIN statement -- that's why one of the test cases is commented out.

Additional food for thought:
```
CREATE VIRTUAL TABLE t1 USING fts4(x, y, languageid="lid");
SELECT * FROM t1 WHERE t1 MATCH 'abc' AND lid=5;

```
Not sure how common the use of the languageid feature is, but the above statement is valid and would create a hidden column named "lid". It doesn't seem like there's any way to handle that right now.  Just figured I'd bring it up since it might help inform discussion on any improvements around synthesized columns.