### PR TITLE
Tell SchemaCrawler not to get routines

### DIFF
--- a/sqlite-migrations/src/main/kotlin/com/squareup/sqlite/migrations/CatalogDatabase.kt
+++ b/sqlite-migrations/src/main/kotlin/com/squareup/sqlite/migrations/CatalogDatabase.kt
@@ -16,6 +16,7 @@ class CatalogDatabase private constructor(
 
     private val schemaCrawlerOptions = SchemaCrawlerOptions().apply {
       schemaInfoLevel = SchemaInfoLevelBuilder.maximum()
+      routineTypes = emptyList() // SQLite does not support stored procedures ("routines" in JBDC)
     }
 
     fun withInitStatements(initStatements: List<String>): CatalogDatabase {


### PR DESCRIPTION
Avoids VerifyMigrationTask emitting "Could not retrieve functions" because SQLite doesn't support routines (stored procedures).

Fixes #1348 