### PR TITLE
update README:

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ apply plugin: 'com.squareup.sqldelight'
 
 On Android, the plugin will create a default database called `Database` using the project package name. For greater customization, you can declare databases explicitly:
 
-#### build.gradle
+`build.gradle`:
 ```groovy
 sqldelight {
     MyDatabase {

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ sqldelight {
         dependency project(':OtherProject')
     }
 
-    // For native targets, chose wether sqlite should be automatically linked.
+    // For native targets, whether sqlite should be automatically linked.
     // Defaults to true.
     linkSqlite = false
 }

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ sqldelight {
 
 #### build.gradle.kts
 
-If you're using kotlin for your gradle files:
+If you're using Kotlin for your Gradle files:
 ```kotlin
 sqldelight {
     database("MyDatabase") {

--- a/README.md
+++ b/README.md
@@ -375,57 +375,48 @@ For Android projects, the plugin will create a default database called `Database
 `build.gradle`:
 ```groovy
 sqldelight {
-    MyDatabase {
-        /**
-         * package name used for the generated MyDatabase.kt
-         */
-        packageName = "com.example.db"
+  MyDatabase {
+    //package name used for the generated MyDatabase.kt
+    packageName = "com.example.db"
 
-        /**
-         * An array of folders where the plugin will read your '.sq' and '.sqm' files.
-         * The folders are relative to the existing source set so if you specify ["db"],
-         * the plugin will look into 'src/main/db'
-         * Defaults to ["sqldelight"] (src/main/sqldelight)
-         */
-        sourceFolders = ["db"]
+    // An array of folders where the plugin will read your '.sq' and '.sqm' files.
+    // The folders are relative to the existing source set so if you specify ["db"],
+    // the plugin will look into 'src/main/db'
+    // Defaults to ["sqldelight"] (src/main/sqldelight)
+    sourceFolders = ["db"]
 
-        /**
-         * The directory where to store '.db' schema files relative to the root of the project.
-         * These files are used to verify that migrations yield a database with the latest schema.
-         *
-         * Defaults to null so the verification tasks will not be created.
-         */
-        schemaOutputDirectory = file("src/main/sqldelight/databases")
+    // The directory where to store '.db' schema files relative to the root of the project.
+    // These files are used to verify that migrations yield a database with the latest schema.
+    // Defaults to null so the verification tasks will not be created.
+    schemaOutputDirectory = file("src/main/sqldelight/databases")
 
-        /**
-         * Optionally specify schema dependencies on other gradle projects
-         */
-        dependency project(':OtherProject')
-    }
+    // Optionally specify schema dependencies on other gradle projects
+    dependency project(':OtherProject')
+  }
 
-    // For native targets, whether sqlite should be automatically linked.
-    // Defaults to true.
-    linkSqlite = false
+  // For native targets, whether sqlite should be automatically linked.
+  // Defaults to true.
+  linkSqlite = false
 }
 ```
 
-#### build.gradle.kts
-
 If you're using Kotlin for your Gradle files:
+
+`build.gradle.kts`
 ```kotlin
 sqldelight {
-    database("MyDatabase") {
-        packageName = "com.example.db"
-        sourceFolders = listOf("db")
-        schemaOutputDirectory = file("build/dbs")
-        dependency(project(":OtherProject"))
-    }
-    linkSqlite = false
+  database("MyDatabase") {
+    packageName = "com.example.db"
+    sourceFolders = listOf("db")
+    schemaOutputDirectory = file("build/dbs")
+    dependency(project(":OtherProject"))
+  }
+  linkSqlite = false
 }
 ```
 
 Snapshots
-=======
+---------
 
 Snapshots of the development version (including the IDE plugin zip) are available in
 [Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/).

--- a/README.md
+++ b/README.md
@@ -350,6 +350,9 @@ The IntelliJ plugin provides language-level features for `.sq` files, including:
  - Right click to copy as valid SQLite
  - Compiler errors in IDE click through to file
 
+It can be installed from Android Studio by navigating<br>
+Android Studio -> Preferences -> Plugins -> Browse repositories -> Search for SQLDelight
+
 Gradle
 ------
 
@@ -367,31 +370,62 @@ buildscript {
 apply plugin: 'com.squareup.sqldelight'
 ```
 
-You can declare databases explicitly in gradle for tighter control of the generated schema:
+On Android, the plugin will create a default database called `Database` using the project package name. For greater customization, you can declare databases explicitly:
 
+#### build.gradle
 ```groovy
 sqldelight {
-  MyDatabase {
-    packageName = "com.example.db"
-    // By default this is ["sqldelight"], and means your sqldelight will be in
-    // folders like 'src/main/db' instead of 'src/main/sqldelight'
-    sourceFolders = ["db"]
+    MyDatabase {
+        /**
+         * package name used for the generated MyDatabase.kt
+         */
+        packageName = "com.example.db"
 
-    // Defaults to file("src/main/sqldelight")
-    schemaOutputDirectory = file("build/dbs")
+        /**
+         * An array of folders where the plugin will read your '.sq' and '.sqm' files.
+         * The folders are relative to the existing source set so if you specify ["db"],
+         * the plugin will look into 'src/main/db'
+         * Defaults to ["sqldelight"] (src/main/sqldelight)
+         */
+        sourceFolders = ["db"]
 
-    // Optionally specify schema dependencies on other gradle projects
-    dependency project(':OtherProject')
-  }
-  
-  // For native targets, chose wether sqlite should be automatically linked.
-  // Defaults to true.
-  linkSqlite = false
+        /**
+         * The directory where to store '.db' schema files relative to the root of the project.
+         * These files are used to verify that migrations yield a database with the latest schema.
+         *
+         * Defaults to null so the verification tasks will not be created.
+         */
+        schemaOutputDirectory = file("src/main/sqldelight/databases")
+
+        /**
+         * Optionally specify schema dependencies on other gradle projects
+         */
+        dependency project(':OtherProject')
+    }
+
+    // For native targets, chose wether sqlite should be automatically linked.
+    // Defaults to true.
+    linkSqlite = false
 }
 ```
 
-The IntelliJ plugin can be installed from Android Studio by navigating<br>
-Android Studio -> Preferences -> Plugins -> Browse repositories -> Search for SQLDelight
+#### build.gradle.kts
+
+If you're using kotlin for your gradle files:
+```kotlin
+sqldelight {
+    database("MyDatabase") {
+        packageName = "com.example.db"
+        sourceFolders = listOf("db")
+        schemaOutputDirectory = file("build/dbs")
+        dependency(project(":OtherProject"))
+    }
+    linkSqlite = false
+}
+```
+
+Snapshots
+=======
 
 Snapshots of the development version (including the IDE plugin zip) are available in
 [Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/).

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ buildscript {
 apply plugin: 'com.squareup.sqldelight'
 ```
 
-On Android, the plugin will create a default database called `Database` using the project package name. For greater customization, you can declare databases explicitly:
+For Android projects, the plugin will create a default database called `Database` using the project package name. For greater customization, you can declare databases explicitly using the Gradle DSL.
 
 `build.gradle`:
 ```groovy


### PR DESCRIPTION
* fix the default value of schemaOutputDirectory
* make it point to src/main/sqldelight/databases like in other parts of
the project
* added build.gradle.kts exemple
* move the IDE plugin sentence to the IntelliJ section and make a
separate section for snapshots